### PR TITLE
Enable save from HTML view when on current version

### DIFF
--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -161,6 +161,14 @@ export function hasUnsavedChanges() {
 }
 
 /**
+ * Returns the current live raw text content of the open file.
+ * @returns {string}
+ */
+export function getLiveRawContent() {
+    return liveRawContent;
+}
+
+/**
  * Resets the saved baseline to the current live content.
  * Called after a successful save so that hasUnsavedChanges() returns false
  * and the unsaved-changes indicator is cleared.

--- a/public/js/ui/ui-functions-click/save-file-copy.js
+++ b/public/js/ui/ui-functions-click/save-file-copy.js
@@ -2,7 +2,7 @@ import { appState } from '../../services/store.js';
 import { getIsCurrentVersion } from '../../editing/editable-state.js';
 import { decodeModalHtml } from '../../services/file-save.js';
 import { saveFileCopy } from '../../editing/save-file-copy.js';
-import { updateUnsavedIndicator, resetUnsavedBaseline } from './load-file-content.js';
+import { updateUnsavedIndicator, resetUnsavedBaseline, getLiveRawContent } from './load-file-content.js';
 import { refreshFileAfterSave } from '../../editing/refresh-file-state.js';
 
 let savePopoverTimer = null;
@@ -31,18 +31,24 @@ function showSavePopover(success) {
  * @returns {Promise<void>}
  */
 export async function handleSaveFileCopy() {
-    const renderToggle = document.getElementById('render_toggle');
-    if (!renderToggle?.checked || !getIsCurrentVersion()) return;
-
+    if (!getIsCurrentVersion()) return;
     if (!appState.dirHandle) return;
 
     const snapshot = appState.openFileSnapshot;
     if (!snapshot) return;
 
-    const preElement = document.querySelector('#modal-content-text pre');
-    if (!preElement) return;
+    const renderToggle = document.getElementById('render_toggle');
+    let textToSave;
 
-    const textToSave = decodeModalHtml(preElement.innerHTML);
+    if (renderToggle?.checked) {
+        // Text view: read from the editable pre element
+        const preElement = document.querySelector('#modal-content-text pre');
+        if (!preElement) return;
+        textToSave = decodeModalHtml(preElement.innerHTML);
+    } else {
+        // HTML view: use the tracked live raw content
+        textToSave = getLiveRawContent();
+    }
 
     try {
         const verified = await saveFileCopy(snapshot, textToSave);

--- a/tests/12-save-button.spec.js
+++ b/tests/12-save-button.spec.js
@@ -36,7 +36,7 @@ async function clickSaveBtn(page) {
 
 test.describe('save button guard conditions', () => {
 
-  test('handler does not save in HTML mode', async ({ page }) => {
+  test('handler saves in HTML mode (current version)', async ({ page }) => {
     await setupMockDirectoryWithSaveSupport(page);
     await page.goto('/');
     await openModal(page);
@@ -44,8 +44,8 @@ test.describe('save button guard conditions', () => {
     await clickSaveBtn(page);
     await page.waitForTimeout(300);
 
-    const savedFiles = await page.evaluate(() => window.__savedFiles);
-    expect(Object.keys(savedFiles)).toHaveLength(0);
+    const deletedFiles = await page.evaluate(() => Object.keys(window.__deletedFiles));
+    expect(deletedFiles).toContain('notes.md-save.gypsum');
   });
 
   test('handler does not save while viewing a historical version', async ({ page }) => {
@@ -507,7 +507,7 @@ test.describe('Ctrl+S keyboard shortcut', () => {
     await expect(page.locator('#save-popover')).toBeVisible();
   });
 
-  test('Ctrl+S does not save when in HTML mode', async ({ page }) => {
+  test('Ctrl+S saves the file in HTML mode / current version', async ({ page }) => {
     await setupMockDirectoryWithSaveSupport(page);
     await page.goto('/');
     await openModal(page);
@@ -516,8 +516,8 @@ test.describe('Ctrl+S keyboard shortcut', () => {
     await page.keyboard.press('Control+s');
     await page.waitForTimeout(300);
 
-    const savedFiles = await page.evaluate(() => window.__savedFiles);
-    expect(Object.keys(savedFiles)).toHaveLength(0);
+    const deletedFiles = await page.evaluate(() => Object.keys(window.__deletedFiles));
+    expect(deletedFiles).toContain('notes.md-save.gypsum');
   });
 
   test('Ctrl+S does not save when viewing a historical version', async ({ page }) => {


### PR DESCRIPTION
Previously the save handler required the text view toggle to be active. Since the HTML view renders from liveRawContent (not the DOM), the save can use that variable directly rather than reading from the <pre> element.

Adds getLiveRawContent() getter to load-file-content.js and branches the save handler on render mode. Two tests updated to reflect the new behaviour.

https://claude.ai/code/session_01AzWvjW6iWTkY39gZX45Yxi