### PR TITLE
Add pagination structure for all file views

### DIFF
--- a/public/css/pagination.css
+++ b/public/css/pagination.css
@@ -1,0 +1,43 @@
+.pagination {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    padding: 16px 8px;
+}
+
+.pagination-btn {
+    min-width: 36px;
+    height: 36px;
+    padding: 0 8px;
+    border: 1px solid var(--border-color, #ccc);
+    background: var(--bg-color, #fff);
+    color: var(--text-color, inherit);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.pagination-btn:hover {
+    background: var(--hover-bg, #f0f0f0);
+}
+
+.pagination-btn--active {
+    background: var(--accent-color, #333);
+    color: var(--accent-text, #fff);
+    border-color: var(--accent-color, #333);
+    font-weight: bold;
+    cursor: default;
+}
+
+.pagination-ellipsis {
+    min-width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted, #888);
+    font-size: 0.9rem;
+    user-select: none;
+}

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -20,3 +20,5 @@ export const VIEWS = {
 
 export const SAVE_FOLDER = '.gypsum';
 export const BACKUP_FILENAME = 'history.gypsum';
+
+export const PAGINATION_SIZE = 50;

--- a/public/js/services/store.js
+++ b/public/js/services/store.js
@@ -37,6 +37,10 @@ export const appState = {
 
   viewState: VIEWS.CARDS.value, // sets initial view state
   sortState: { property: 'lastModified', direction: 'desc'},
+  paginationState: {
+    currentPage: 1,
+    pageFileIds: new Set(),
+  },
 
   dirHandle: null,       // FileSystemDirectoryHandle — set by directory loader, null otherwise
   openFileSnapshot: null,    // { filepath, filename, content } captured when modal opens

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -18,6 +18,7 @@ import { handleDeleteFilter } from './ui-functions-click/filter-delete.js';
 import { handleFilterToggleActive } from './ui-functions-click/filter-toggle-active.js';
 import { handleHistorySelectChange } from './ui-functions-click/history-select-change.js';
 import { handleSaveFileCopy } from './ui-functions-click/save-file-copy.js';
+import { handlePageChange } from './pagination/handle-page-change.js';
 
 /**
  * Adds event listeners to the document for click, change, and keyup events.
@@ -47,6 +48,7 @@ const clickActionHandlers = {
     'delete-filter': handleDeleteFilter,
     'filter-toggleactive':handleFilterToggleActive,
     'save-file-copy': handleSaveFileCopy,
+    'change-page': handlePageChange,
 };
 
 const changeActionHandlers = {

--- a/public/js/ui/pagination/check-file-on-page.js
+++ b/public/js/ui/pagination/check-file-on-page.js
@@ -1,0 +1,12 @@
+import { appState } from '../../services/store.js';
+
+/**
+ * Returns true if the file is on the current page.
+ * pageFileIds is pre-computed from visibleFiles, which already applies the active
+ * AND/OR filter mode, so no second filter check is needed here.
+ * @param {number} fileId
+ * @returns {boolean}
+ */
+export function checkFileOnPage(fileId) {
+    return appState.paginationState.pageFileIds.has(fileId);
+}

--- a/public/js/ui/pagination/handle-page-change.js
+++ b/public/js/ui/pagination/handle-page-change.js
@@ -1,0 +1,14 @@
+import { appState } from '../../services/store.js';
+import { renderData } from '../ui-functions-render/a-render-all-files.js';
+
+/**
+ * Handles a click on a pagination page button.
+ * Sets the current page and re-renders, keeping the chosen page active.
+ * @param {Event} evt - The click event.
+ * @param {HTMLElement} target - The element with data-action="change-page".
+ */
+export function handlePageChange(evt, target) {
+    const page = parseInt(target.dataset.page, 10);
+    appState.paginationState.currentPage = page;
+    renderData(true, true); // keepPage=true so we stay on the chosen page
+}

--- a/public/js/ui/pagination/render-pagination.js
+++ b/public/js/ui/pagination/render-pagination.js
@@ -1,0 +1,54 @@
+import { appState } from '../../services/store.js';
+import { PAGINATION_SIZE } from '../../constants.js';
+
+/**
+ * Renders pagination button HTML for the given total number of visible files.
+ * Returns an empty string when the total fits on one page.
+ * Button format: 1 ... {c-1} {c} {c+1} ... n
+ * @param {number} totalVisible - Total number of visible (filtered) files.
+ * @returns {string} HTML string for the pagination nav, or '' if not needed.
+ */
+export function renderPagination(totalVisible) {
+    const totalPages = Math.ceil(totalVisible / PAGINATION_SIZE);
+    if (totalPages <= 1) return '';
+
+    const c = appState.paginationState.currentPage;
+    const n = totalPages;
+
+    const items = [];
+
+    // Always show first page
+    items.push(1);
+
+    // Ellipsis between 1 and c-1 if there is a gap
+    if (c - 1 > 2) items.push('...');
+
+    // Page before current (if it exists and isn't page 1)
+    if (c - 1 > 1) items.push(c - 1);
+
+    // Current page (skip if it is already first or last — those are always added)
+    if (c !== 1 && c !== n) items.push(c);
+
+    // Page after current (if it exists and isn't last)
+    if (c + 1 < n) items.push(c + 1);
+
+    // Ellipsis between c+1 and last page if there is a gap
+    if (c + 2 < n) items.push('...');
+
+    // Always show last page
+    if (n > 1) items.push(n);
+
+    let html = '<nav class="pagination">';
+
+    for (const item of items) {
+        if (item === '...') {
+            html += '<span class="pagination-ellipsis">...</span>';
+        } else {
+            const isActive = item === c;
+            html += `<button class="pagination-btn${isActive ? ' pagination-btn--active' : ''}" data-action="change-page" data-page="${item}">${item}</button>`;
+        }
+    }
+
+    html += '</nav>';
+    return html;
+}

--- a/public/js/ui/render-file-list-grid.js
+++ b/public/js/ui/render-file-list-grid.js
@@ -5,7 +5,7 @@
 import { appState } from '../services/store.js';
 import { renderFilename } from './ui-functions-render/render-filename.js';
 import { renderTags } from './ui-functions-render/render-tags.js';
-import { checkFilesToShow } from './ui-functions-search/a-check-files-to-show.js';
+import { checkFileOnPage } from './pagination/check-file-on-page.js';
 
 /**
  * Renders the list of files as a grid of cards.
@@ -22,7 +22,7 @@ export function renderFileList_grid(renderEverything) {
 
     for (const file of appState.myFiles) {
 
-        if (checkFilesToShow(file.id) === true || renderEverything===true ) {
+        if (checkFileOnPage(file.id)) {
      //   console.log(file);
 
         // construct the html for the array of tags for this file

--- a/public/js/ui/render-file-list-list.js
+++ b/public/js/ui/render-file-list-list.js
@@ -5,7 +5,7 @@
 import { appState } from '../services/store.js';
 import { renderFilename } from './ui-functions-render/render-filename.js';
 import { renderTags } from './ui-functions-render/render-tags.js';
-import { checkFilesToShow } from './ui-functions-search/a-check-files-to-show.js';
+import { checkFileOnPage } from './pagination/check-file-on-page.js';
 
 /**
  * Renders the list of files as an ordered list.
@@ -19,7 +19,7 @@ export function renderFileList_list(renderEverything) {
     let file_html = `<ol class="list-view">`; 
 
     for (const file of appState.myFiles) {
-        if (checkFilesToShow(file.id) === true || renderEverything === true ) {
+        if (checkFileOnPage(file.id)) {
 
             const filename_html = renderFilename(file.filename);
 

--- a/public/js/ui/render-file-list-search.js
+++ b/public/js/ui/render-file-list-search.js
@@ -1,6 +1,6 @@
 
 import { appState } from '../services/store.js';
-import { checkFilesToShow } from './ui-functions-search/a-check-files-to-show.js';
+import { checkFileOnPage } from './pagination/check-file-on-page.js';
 import { renderFilename } from './ui-functions-render/render-filename.js';
 import { renderTags } from './ui-functions-render/render-tags.js';
 
@@ -15,7 +15,7 @@ export function renderFileList_search(renderEverything) {
             <div class="search-results-view">`;
 
     for (const file of appState.myFiles) {
-        if (checkFilesToShow(file.id) === true || renderEverything === true) {
+        if (checkFileOnPage(file.id)) {
 
             const filename_html = renderFilename(file.filename);
 

--- a/public/js/ui/ui-functions-render/a-render-all-files.js
+++ b/public/js/ui/ui-functions-render/a-render-all-files.js
@@ -4,35 +4,63 @@ import { renderFileList_table } from "../render-file-list-table.js";
 import { renderFileList_list } from "../render-file-list-list.js";
 import { renderFileList_search } from "../render-file-list-search.js";
 import { countActiveFilters } from "../ui-functions-search/a-count-activefilters.js";
+import { checkFilesToShow } from "../ui-functions-search/a-check-files-to-show.js";
 import { VIEWS } from "../../constants.js";
+import { PAGINATION_SIZE } from "../../constants.js";
 import { applyHighlights } from "../ui-functions-highlight/apply-highlights.js";
+import { renderPagination } from "../pagination/render-pagination.js";
 
 /**
  * Triggers the rendering of the file list.
  * @param {boolean} [fullRender=true] - A flag to indicate whether to perform a full render or just update rows (for table view).
+ * @param {boolean} [keepPage=false] - When true, stays on the current page instead of resetting to page 1.
  * @returns {void}
  */
-export function renderData(fullRender = true) {
+export function renderData(fullRender = true, keepPage = false) {
 
-    renderFiles(fullRender);
+    renderFiles(fullRender, keepPage);
 
 }
 
 /**
  * Orchestrates the rendering of files based on the current view state and active filters.
+ * Computes the current page's file IDs into appState.paginationState.pageFileIds before
+ * calling the view renderer, then appends pagination controls below the output.
  * @param {boolean} [fullRender=true] - A flag to indicate whether to perform a full render.
+ * @param {boolean} [keepPage=false] - When true, stays on the current page instead of resetting to page 1.
  * @returns {void}
  */
-export function renderFiles(fullRender = true) {
+export function renderFiles(fullRender = true, keepPage = false) {
 
     // check if no active filters applied
     const activeFilterCount = countActiveFilters();
-    let renderEverything = "";
-    if (activeFilterCount === 0 || appState.search.filters.size === 0) {
-        renderEverything = true;
-     }
+    const renderEverything = (activeFilterCount === 0 || appState.search.filters.size === 0);
 
-//    const outputElement = document.getElementById("output");
+    // Reset to page 1 unless navigating within pages
+    if (!keepPage) {
+        appState.paginationState.currentPage = 1;
+    }
+
+    // Compute the full visible list for pagination math; appState.myFiles is never mutated
+    const visibleFiles = renderEverything
+        ? appState.myFiles
+        : appState.myFiles.filter(f => checkFilesToShow(f.id) === true);
+
+    // Clamp current page in case a filter reduces the total number of pages
+    const totalPages = Math.max(1, Math.ceil(visibleFiles.length / PAGINATION_SIZE));
+    if (appState.paginationState.currentPage > totalPages) {
+        appState.paginationState.currentPage = totalPages;
+    }
+
+    // Store the IDs for the current page so renderers can check membership via checkFileOnPage
+    const start = (appState.paginationState.currentPage - 1) * PAGINATION_SIZE;
+    appState.paginationState.pageFileIds = new Set(
+        visibleFiles.slice(start, start + PAGINATION_SIZE).map(f => f.id)
+    );
+
+    // Remove stale pagination nav (required for the table fullRender=false path)
+    document.querySelector('.pagination')?.remove();
+
     switch(appState.viewState) {
         case VIEWS.CARDS.value:
             renderFileList_grid(renderEverything);
@@ -49,6 +77,12 @@ export function renderFiles(fullRender = true) {
         default:
             renderFileList_grid(renderEverything);
             break;
+    }
+
+    // Append pagination nav below the rendered content
+    const paginationHtml = renderPagination(visibleFiles.length);
+    if (paginationHtml) {
+        document.getElementById('output').insertAdjacentHTML('beforeend', paginationHtml);
     }
 
     applyHighlights(); // need to apply again because we have a complete refresh of output html

--- a/public/js/ui/ui-functions-table/render-table-rows.js
+++ b/public/js/ui/ui-functions-table/render-table-rows.js
@@ -1,7 +1,7 @@
 import { appState } from '../../services/store.js';
 import { renderFilenamePlusOpenBtn } from '../ui-functions-render/render-filename.js';
 import { renderTags } from '../ui-functions-render/render-tags.js';
-import { checkFilesToShow } from '../ui-functions-search/a-check-files-to-show.js';
+import { checkFileOnPage } from '../pagination/check-file-on-page.js';
 
 /**
  * Renders the rows for the table view.
@@ -15,7 +15,7 @@ export function renderTableRows(current_props, renderEverything) {
     let rowsHtml = '';
 
     for (const file of appState.myFiles) {
-        if (checkFilesToShow(file.id) === true || renderEverything === true ) {
+        if (checkFileOnPage(file.id)) {
 
             const cellsHtml = current_props.map(prop => {
                 const value = file[prop.name];

--- a/public/style.css
+++ b/public/style.css
@@ -29,3 +29,4 @@
 @import url("css/button-save.css");
 @import url("css/button-close-modal.css");
 @import url("css/checkbox.css");
+@import url("css/pagination.css");


### PR DESCRIPTION
- New public/js/ui/pagination/ module with three files:
  - check-file-on-page.js: single Set.has() check used by all renderers
  - render-pagination.js: builds '1 ... c-1 c c+1 ... n' button HTML
  - handle-page-change.js: click handler for data-action="change-page"
- Add PAGINATION_SIZE = 50 constant to constants.js
- Add paginationState { currentPage, pageFileIds } to appState in store.js
- Orchestrator (a-render-all-files.js) computes pageFileIds before each render, resets to page 1 by default, appends pagination nav after render; keepPage=true preserves the chosen page when navigating
- Four renderers swap checkFilesToShow for checkFileOnPage (one-line change each): render-file-list-grid, render-file-list-list, render-file-list-search, render-table-rows
- Register 'change-page' in event-listeners-add.js clickActionHandlers
- Add public/css/pagination.css and import in style.css

https://claude.ai/code/session_01ELFSJttH2DExRZgPKCXiKn