### PR TITLE
Update docs to reflect pagination implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ These are non-negotiable. Do not work against them.
 ### 4. One file, one responsibility
 - Each module handles a single logical concern.
 - `ui-functions-click/` has one file per user action. Follow this pattern for new actions.
-- CSS is split into 26 component-scoped files. Add a new file for a new component; do not
+- CSS is split into 27 component-scoped files. Add a new file for a new component; do not
   bloat an existing one.
 
 ### 5. No frameworks
@@ -79,6 +79,7 @@ Key structures:
 - `appState.search.matchingFiles` — inverted map: `fileId → Set<filterId>` (used for AND/OR)
 - `appState.viewState` — current view mode
 - `appState.sortState` — current sort column and direction
+- `appState.paginationState` — `{ currentPage, pageFileIds }`: current page number and the Set of file IDs visible on that page (recomputed on every render)
 
 ### Event handling: `data-action` attributes, not inline handlers
 
@@ -122,6 +123,7 @@ in `event-listeners-add.js` maps action names to handler functions.
 | `public/js/ui/ui-functions-search/` | Search orchestration and filter logic |
 | `public/js/ui/ui-functions-render/` | Rendering utilities and orchestrator |
 | `public/js/ui/render-file-list-*.js` | View-specific renderers (grid/table/list/search) |
+| `public/js/ui/pagination/` | Pagination: page-ID check, button renderer, click handler |
 | `public/css/` | Component-scoped CSS modules |
 | `inline-scripts-from-files.js` | Build-time bundler (do not run manually) |
 | `.github/workflows/bundle.yaml` | CI/CD pipeline — produces single-file HTML artefact |
@@ -205,7 +207,6 @@ the matching browser binary and system dependencies.
 
 These are accepted trade-offs, not bugs:
 
-- **~1000 file limit** — no pagination or virtual scrolling yet (roadmap item)
 - **Read-only** — files cannot be edited in the app
 - **Top-level folder only** — subdirectories are ignored
 - **Two-level tags only** — `#parent/child` works; `#a/b/c` does not

--- a/DATA-STRUCTURES.md
+++ b/DATA-STRUCTURES.md
@@ -133,6 +133,27 @@ Note that `"personal"` appears in `"orphan"` because it only ever appears as a p
 
 ---
 
+## Pagination state (`appState.paginationState`)
+
+```js
+appState.paginationState = {
+  currentPage: 1,          // 1-based index of the currently displayed page
+  pageFileIds: new Set(),   // IDs of the files visible on the current page
+}
+```
+
+`pageFileIds` is recomputed on every render inside `a-render-all-files.js`:
+
+1. The full visible list is built — either all files (no active filters) or the subset that passes the active AND/OR filter check via `checkFilesToShow`.
+2. The list is sliced to `PAGINATION_SIZE` entries starting at `(currentPage - 1) * PAGINATION_SIZE`.
+3. The IDs of that slice are stored as a `Set` in `pageFileIds`.
+
+Each view renderer calls `checkFileOnPage(file.id)` (`pagination/check-file-on-page.js`), which is a single `pageFileIds.has(fileId)` lookup. Because `pageFileIds` was already built from the correctly filtered list, no second filter check is needed.
+
+`currentPage` resets to `1` on every render except when triggered by a page-button click (`handle-page-change.js` passes `keepPage=true`). It is also clamped to the last available page if a filter reduces the total number of pages.
+
+---
+
 ## Where the structures are built
 
 | Structure | Built in | Called from |

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A browser based view of text files saved on your computer. I named it Gypsum bec
 4. You can filter notes based on selected tags, either with an `and` filter or an `or` filter.
 5. Add a tag of the format `#color/red` (ie `#color/[color]`) and it will use this colour in the file viewer for that file, assuming it is a valid html color name.
 6. You can add simple YAML properties to the files, in front matter (ie key value pairs below one `---`and above another `---`). These are visible as columns in the table view.
+7. Files are paginated (50 per page) across all views, with page navigation shown below the file list. The page resets to 1 whenever the sort order or active filters change.
 
 ## Limitations
 
-1. There are many limitations, but perhaps the biggest one is the number of files it can cope with. Probably no more than a thousand before the browser starts complaining. This can be relatively easily rectified with selective rendering of files (eg pagination) but this is not yet implemented.
-2. For tag hierarchies only one level of tag classifcation is allowed. Ie `#that/this` is fine `#that/this/them` isn't.
-3. Editing still not quite there.
-4. Technically this works on mobile - screen sizes work etc - but because accessing the file system is incredibly slow it is basically broken. It will take several seconds to load a handful of files. This is a shame!
+1. For tag hierarchies only one level of tag classifcation is allowed. Ie `#that/this` is fine `#that/this/them` isn't.
+2. Editing still not quite there.
+3. Technically this works on mobile - screen sizes work etc - but because accessing the file system is incredibly slow it is basically broken. It will take several seconds to load a handful of files. This is a shame!
 
 ## Immediate to do list
 
@@ -45,5 +45,4 @@ See [DATA-STRUCTURES.md](DATA-STRUCTURES.md) for a reference to the in-memory da
 ## Roadmap
 
 1. Table filtering is now active for tags... but could do this for other properties too. Not sure how useful this will be as currently you can ctrl+F everything.
-2. Pagination of rendered files to cope with large numbers of files. In future this could be implemented by a virtual DOM that destroy and creates html elements depending on scroll position but not in the immediate plans.
-3. Alongside this some sort of very simple DOM diffing process might be considered.
+2. Some sort of very simple DOM diffing process might be considered to avoid full re-renders on state change.


### PR DESCRIPTION
- README: remove ~1000 file limitation, add pagination to feature list, remove pagination from roadmap
- CLAUDE.md: remove ~1000 file limit from known limitations, add paginationState to appState key structures, add pagination/ to file map, update CSS file count to 27
- DATA-STRUCTURES.md: add paginationState section explaining pageFileIds lifecycle and the checkFileOnPage lookup pattern

https://claude.ai/code/session_01ELFSJttH2DExRZgPKCXiKn