### PR TITLE
Fix pagination ellipsis bug, current-page indicator, and renderData p…

### DIFF
--- a/public/css/pagination.css
+++ b/public/css/pagination.css
@@ -23,12 +23,20 @@
     background: var(--hover-bg, #f0f0f0);
 }
 
-.pagination-btn--active {
+.pagination-current {
+    min-width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 8px;
     background: var(--accent-color, #333);
     color: var(--accent-text, #fff);
-    border-color: var(--accent-color, #333);
+    border: 1px solid var(--accent-color, #333);
+    border-radius: 4px;
+    font-size: 0.9rem;
     font-weight: bold;
-    cursor: default;
+    user-select: none;
 }
 
 .pagination-ellipsis {

--- a/public/js/editing/refresh-file-state.js
+++ b/public/js/editing/refresh-file-state.js
@@ -2,7 +2,7 @@ import { appState } from '../services/store.js';
 import { getFileDataAndMetadata } from '../services/file-parsing/file-info.js';
 import { buildParentMap } from '../services/file-parsing/tag-taxon.js';
 import { renderTagTaxonomy } from '../ui/render-tag-taxonmy.js';
-import { renderData } from '../ui/ui-functions-render/a-render-all-files.js';
+import { renderFiles } from '../ui/ui-functions-render/a-render-all-files.js';
 import { searchFiles } from '../ui/ui-functions-search/a-search-files.js';
 import { processSeachResults } from '../ui/ui-functions-search/a-search-orchestrator.js';
 
@@ -45,7 +45,7 @@ export async function refreshFileAfterSave(snapshot) {
             renderTagTaxonomy();
         }
 
-        renderData();
+        renderFiles();
 
         if (appState.search.filters.size > 0) {
             const filterIds = [...appState.search.filters.keys()];

--- a/public/js/ui/pagination/handle-page-change.js
+++ b/public/js/ui/pagination/handle-page-change.js
@@ -1,5 +1,5 @@
 import { appState } from '../../services/store.js';
-import { renderData } from '../ui-functions-render/a-render-all-files.js';
+import { renderFiles } from '../ui-functions-render/a-render-all-files.js';
 
 /**
  * Handles a click on a pagination page button.
@@ -10,5 +10,5 @@ import { renderData } from '../ui-functions-render/a-render-all-files.js';
 export function handlePageChange(evt, target) {
     const page = parseInt(target.dataset.page, 10);
     appState.paginationState.currentPage = page;
-    renderData(true, true); // keepPage=true so we stay on the chosen page
+    renderFiles(true, true); // keepPage=true so we stay on the chosen page
 }

--- a/public/js/ui/pagination/render-pagination.js
+++ b/public/js/ui/pagination/render-pagination.js
@@ -20,8 +20,9 @@ export function renderPagination(totalVisible) {
     // Always show first page
     items.push(1);
 
-    // Ellipsis between 1 and c-1 if there is a gap
-    if (c - 1 > 2) items.push('...');
+    // Leading gap: ellipsis only when 2+ pages are hidden; otherwise emit the single hidden page
+    if (c - 1 > 3) items.push('...');
+    else if (c - 1 === 3) items.push(2);
 
     // Page before current (if it exists and isn't page 1)
     if (c - 1 > 1) items.push(c - 1);
@@ -32,20 +33,22 @@ export function renderPagination(totalVisible) {
     // Page after current (if it exists and isn't last)
     if (c + 1 < n) items.push(c + 1);
 
-    // Ellipsis between c+1 and last page if there is a gap
-    if (c + 2 < n) items.push('...');
+    // Trailing gap: ellipsis only when 2+ pages are hidden; otherwise emit the single hidden page
+    if (c + 3 < n) items.push('...');
+    else if (c + 2 < n) items.push(c + 2);
 
-    // Always show last page
-    if (n > 1) items.push(n);
+    // Always show last page (n >= 2 is guaranteed by the early return above)
+    items.push(n);
 
     let html = '<nav class="pagination">';
 
     for (const item of items) {
         if (item === '...') {
             html += '<span class="pagination-ellipsis">...</span>';
+        } else if (item === c) {
+            html += `<span class="pagination-current">${item}</span>`;
         } else {
-            const isActive = item === c;
-            html += `<button class="pagination-btn${isActive ? ' pagination-btn--active' : ''}" data-action="change-page" data-page="${item}">${item}</button>`;
+            html += `<button class="pagination-btn" data-action="change-page" data-page="${item}">${item}</button>`;
         }
     }
 

--- a/public/js/ui/ui-functions-click/sort-object.js
+++ b/public/js/ui/ui-functions-click/sort-object.js
@@ -1,7 +1,7 @@
 import { sortAppStateFiles } from '../../services/file-object-sort.js';
 import { appState, FILE_PROPERTIES, propertySortMap } from '../../services/store.js';
 import { renderFileList_table } from '../render-file-list-table.js';
-import { renderData } from '../ui-functions-render/a-render-all-files.js';
+import { renderFiles } from '../ui-functions-render/a-render-all-files.js';
 
 /**
  * Handles the click event to sort the file list by a specific property.
@@ -41,7 +41,7 @@ export function handleSortObject(evt, element){
     // sort the appState.myFiles object with the selected property, type and direction.
     sortAppStateFiles(sortProp, sortType, sortDirection);
     // then render on this sorted object (only table rows hence false arg)
-    renderData(false);
+    renderFiles(false);
 
     // appState.sortState with current sort state
     Object.assign(currentSort, { property: sortProp, direction: sortDirection });

--- a/public/js/ui/ui-functions-click/view-change.js
+++ b/public/js/ui/ui-functions-click/view-change.js
@@ -1,4 +1,4 @@
-import { renderData } from "../ui-functions-render/a-render-all-files.js";
+import { renderFiles } from "../ui-functions-render/a-render-all-files.js";
 import { appState } from '../../services/store.js';
 
 /**
@@ -13,5 +13,5 @@ export function handleViewSelect(evt, selectElement) {
     const viewSelectElem = document.querySelector('[data-action="view-select"]');
     appState.viewState = viewSelectElem.value;
 
-    renderData();
+    renderFiles();
 }

--- a/public/js/ui/ui-functions-render/a-render-all-files.js
+++ b/public/js/ui/ui-functions-render/a-render-all-files.js
@@ -11,18 +11,6 @@ import { applyHighlights } from "../ui-functions-highlight/apply-highlights.js";
 import { renderPagination } from "../pagination/render-pagination.js";
 
 /**
- * Triggers the rendering of the file list.
- * @param {boolean} [fullRender=true] - A flag to indicate whether to perform a full render or just update rows (for table view).
- * @param {boolean} [keepPage=false] - When true, stays on the current page instead of resetting to page 1.
- * @returns {void}
- */
-export function renderData(fullRender = true, keepPage = false) {
-
-    renderFiles(fullRender, keepPage);
-
-}
-
-/**
  * Orchestrates the rendering of files based on the current view state and active filters.
  * Computes the current page's file IDs into appState.paginationState.pageFileIds before
  * calling the view renderer, then appends pagination controls below the output.

--- a/public/main.js
+++ b/public/main.js
@@ -3,7 +3,7 @@ import { loadDirectoryFileHandles } from './js/services/directory-handler.js';
 import { renderTagTaxonomy } from './js/ui/render-tag-taxonmy.js';
 import { sortAppStateFiles } from './js/services/file-object-sort.js';
 import { appState, FILE_PROPERTIES } from './js/services/store.js';
-import { renderData } from './js/ui/ui-functions-render/a-render-all-files.js';
+import { renderFiles } from './js/ui/ui-functions-render/a-render-all-files.js';
 import { addActionHandlers } from './js/ui/event-listeners-add.js';
 import { VIEWS } from './js/constants.js';
 
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const loadFolderButton = document.querySelector('[data-click-loadfolder]');
     loadFolderButton.addEventListener('click', async function () {
         await loadDirectoryData();
-        renderData();
+        renderFiles();
         addActionHandlers();
     });
 
@@ -51,7 +51,7 @@ document.addEventListener('DOMContentLoaded', function () {
  */
 async function conductor() {
     await loadData();
-    renderData();
+    renderFiles();
     addActionHandlers();
 }
 


### PR DESCRIPTION
…assthrough

- Ellipsis now only appears when it hides 2+ pages; a single hidden page is emitted directly (e.g. '1 2 3 4 5' instead of '1 2 3 … 5')
- Current page rendered as <span class="pagination-current"> instead of a button with data-action, making it naturally non-interactive
- Remove dead `if (n > 1)` guard in renderPagination (n >= 2 guaranteed)
- Delete renderData passthrough wrapper; all callers now import renderFiles directly, consistent with a-search-orchestrator.js which already did so

https://claude.ai/code/session_01RgvPphJDaJ7NctmznhDnwx