### PR TITLE
Refactor load-file-content.js into focused modules

### DIFF
--- a/public/js/editing/history-navigation.js
+++ b/public/js/editing/history-navigation.js
@@ -1,0 +1,33 @@
+import { appState } from '../services/store.js';
+import { parseContent } from '../services/parse-content.js';
+import { syncFromDom } from './manage-unsaved-changes.js';
+import { getIsCurrentVersion, setIsCurrentVersion } from './editable-state.js';
+import { fileContentRender } from '../ui/ui-functions-render/render-file-content.js';
+
+/**
+ * Restores the modal to the live file content (undoes any historical selection).
+ * @returns {void}
+ */
+export function restoreCurrentContent() {
+    appState.editSession.activeRaw = appState.editSession.liveRaw;
+    appState.editSession.activeHtml = appState.editSession.liveHtml;
+    setIsCurrentVersion(true);
+    fileContentRender();
+}
+
+/**
+ * Loads a historical content string into the modal.
+ * @param {string} historicalRaw - The raw file text from history to render.
+ * @returns {void}
+ */
+export function loadHistoricalContent(historicalRaw) {
+    if (getIsCurrentVersion()) {
+        syncFromDom();
+        appState.editSession.liveHtml = parseContent(appState.editSession.liveRaw);
+    }
+
+    setIsCurrentVersion(false);
+    appState.editSession.activeRaw = historicalRaw;
+    appState.editSession.activeHtml = parseContent(historicalRaw);
+    fileContentRender();
+}

--- a/public/js/editing/manage-unsaved-changes.js
+++ b/public/js/editing/manage-unsaved-changes.js
@@ -1,0 +1,64 @@
+import { appState } from '../services/store.js';
+
+/**
+ * Returns the editable content element when in txt mode, null in html mode.
+ * Html output must never be used as a content source — returning null enforces that.
+ * Single point of truth for both the mode check and the DOM selector.
+ * @returns {Element|null}
+ */
+export function getEditorElement() {
+    return appState.editState
+        ? document.querySelector('#modal-content-text .text-editor')
+        : null;
+}
+
+/**
+ * Reads the editor content from the DOM into liveRaw and activeRaw.
+ * Both variables are always updated together to keep them in sync on the current version.
+ */
+function readEditorIntoState() {
+    const el = getEditorElement();
+    if (!el) return;
+    appState.editSession.liveRaw = el.innerText;
+    appState.editSession.activeRaw = appState.editSession.liveRaw;
+}
+
+/**
+ * Pulls the current editable content from the DOM into liveRaw / activeRaw.
+ * innerText is not read in the input hot path because it forces a synchronous layout flush.
+ * Instead, consumers that need up-to-date content (toggle, history browse) call this
+ * function lazily, paying the layout cost only when they actually need the value.
+ */
+export function syncFromDom() {
+    if (!appState.editSession.isDirty) return;
+    readEditorIntoState();
+}
+
+/**
+ * Returns true if the live content differs from the content when the modal was opened.
+ * @returns {boolean}
+ */
+export function hasUnsavedChanges() {
+    return appState.editSession.isDirty;
+}
+
+/**
+ * Returns the current live raw text content of the open file.
+ * @returns {string}
+ */
+export function getLiveRawContent() {
+    return appState.editSession.liveRaw;
+}
+
+/**
+ * Resets the saved baseline to the current live content.
+ * Called after a successful save so that hasUnsavedChanges() returns false
+ * and the unsaved-changes indicator is cleared.
+ * @returns {void}
+ */
+export function resetUnsavedBaseline() {
+    readEditorIntoState();
+    appState.editSession.openNormalized = appState.editSession.liveRaw.trimEnd();
+    appState.editSession.openTextLen = appState.editSession.openNormalized.replace(/\n/g, '').length;
+    appState.editSession.isDirty = false;
+}

--- a/public/js/services/store.js
+++ b/public/js/services/store.js
@@ -44,6 +44,16 @@ export const appState = {
 
   editState: false,   // true = txt mode, false = html mode; drives the modal render toggle
 
+  editSession: {
+    activeRaw:      '',   // content currently displayed (current or historical)
+    activeHtml:     '',
+    liveRaw:        '',   // true current content (preserved during history browse)
+    liveHtml:       '',
+    openNormalized: '',   // \r\n-unified, trimEnd baseline set on file open
+    openTextLen:    0,    // length of openNormalized without \n chars (fast-path gate)
+    isDirty:        false,
+  },
+
   dirHandle: null,       // FileSystemDirectoryHandle — set by directory loader, null otherwise
   openFileSnapshot: null,    // { filepath, filename, content } captured when modal opens
   closeSnapshot: null,   // { filepath, filename, content } captured just before modal closes

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -9,7 +9,8 @@ import { handleFilterModeToggle } from './ui-functions-click/filter-mode-toggle.
 import { handleClearFilters } from './ui-functions-click/clear-filters.js';
 import { handleViewSelect } from './ui-functions-click/view-change.js';
 import { handleCloseModal, handleOpenFileContent, handeCloseModalOutside, handleDiscardChanges, handleKeepEditing } from './ui-functions-click/open-file-content-view-trans.js';
-import { handleToggleRenderText, handleFileContentInput } from './ui-functions-click/load-file-content.js';
+import { handleToggleRenderText } from './ui-functions-click/toggle-render-text.js';
+import { handleFileContentInput } from './ui-functions-click/file-content-input.js';
 import { handleSortObject } from './ui-functions-click/sort-object.js';
 import { handleContentSearchToggle } from './ui-functions-click/search-content-toggle.js';
 import { handleFullscreenToggle } from './ui-functions-click/fullscreen-toggle.js';

--- a/public/js/ui/ui-functions-click/file-content-input.js
+++ b/public/js/ui/ui-functions-click/file-content-input.js
@@ -1,0 +1,29 @@
+import { appState } from '../../services/store.js';
+import { scheduleAutosave } from '../../editing/autosave.js';
+import { updateUnsavedIndicator } from '../ui-functions-render/render-file-content.js';
+
+/**
+ * Updates dirty state and the unsaved indicator on each edit.
+ * Hot-path design: pre.textContent.length is read on every keystroke because it is
+ * non-layout-forcing (raw text nodes only, no CSS). pre.innerText forces a synchronous
+ * layout flush and is only read when textContent length matches the open baseline —
+ * the rare case where content might have reverted to the original (or a newline was
+ * inserted/removed without changing the character count).
+ * @param {Event} evt - The input event from the contentEditable pre element.
+ * @returns {void}
+ */
+export function handleFileContentInput(evt) {
+    scheduleAutosave();
+    const pre = evt.target;
+    const session = appState.editSession;
+    if (pre.textContent.length !== session.openTextLen) {
+        // Fast path: length mismatch means content definitely changed — no innerText read needed
+        if (!session.isDirty) { session.isDirty = true; updateUnsavedIndicator(); }
+        return;
+    }
+    // Slow path: same textContent length — might have reverted; innerText read required
+    session.liveRaw = pre.innerText;
+    session.activeRaw = session.liveRaw;
+    session.isDirty = session.liveRaw.trimEnd() !== session.openNormalized;
+    updateUnsavedIndicator();
+}

--- a/public/js/ui/ui-functions-click/history-select-change.js
+++ b/public/js/ui/ui-functions-click/history-select-change.js
@@ -1,5 +1,5 @@
 import { appState } from '../../services/store.js';
-import { restoreCurrentContent, loadHistoricalContent } from './load-file-content.js';
+import { restoreCurrentContent, loadHistoricalContent } from '../../editing/history-navigation.js';
 
 /**
  * Handles selection of a version from the history select in the file content modal.

--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -1,67 +1,9 @@
 import { appState } from '../../services/store.js';
 import { parseContent } from '../../services/parse-content.js';
-import { highlightPropMatches } from '../ui-functions-highlight/apply-highlights.js';
-import { applyDiffHighlights, clearDiffHighlights } from '../ui-functions-highlight/diff-highlight.js';
 import { saveBackupEntry } from '../../editing/local-backup.js';
 import { loadHistorySelect } from './setup-history-select.js';
-import { getIsCurrentVersion, setIsCurrentVersion } from '../../editing/editable-state.js';
-import { scheduleAutosave } from '../../editing/autosave.js';
-
-// Represents the content currently visible in the modal (could be historical)
-let activeRawContent;
-let activeHtmlContent;
-
-// Represents the "true" current state of the file, preserved during history browsing
-let liveRawContent;
-let liveHtmlContent;
-
-// Normalised baseline set once when the file opens: \r\n unified, trailing whitespace
-// stripped. Matches the form contentEditable returns via innerText.
-let openContentNormalized;
-
-// The <pre> renders newlines as <br> elements. pre.textContent ignores <br> (non-layout-
-// forcing); pre.innerText converts each <br> to \n (layout-forcing). Stripping \n from
-// openContentNormalized gives the equivalent textContent length, used in handleFileContentInput
-// as a cheap gate: if lengths differ the content definitely changed and we skip the innerText
-// read entirely; only when lengths match do we pay for the full innerText comparison.
-let openTextContentLength = 0;
-
-// True when the user has made edits not yet matching the open baseline.
-let isDirtyFlag = false;
-
-/**
- * Returns the editable content element when in txt mode, null in html mode.
- * Html output must never be used as a content source — returning null enforces that.
- * Single point of truth for both the mode check and the DOM selector.
- * @returns {Element|null}
- */
-export function getEditorElement() {
-    return appState.editState
-        ? document.querySelector('#modal-content-text .text-editor')
-        : null;
-}
-
-/**
- * Reads the editor content from the DOM into liveRawContent and activeRawContent.
- * Both variables are always updated together to keep them in sync on the current version.
- */
-function readEditorIntoState() {
-    const el = getEditorElement();
-    if (!el) return;
-    liveRawContent = el.innerText;
-    activeRawContent = liveRawContent;
-}
-
-/**
- * Pulls the current editable content from the DOM into liveRawContent / activeRawContent.
- * innerText is not read in the input hot path because it forces a synchronous layout flush.
- * Instead, consumers that need up-to-date content (toggle, history browse) call this
- * function lazily, paying the layout cost only when they actually need the value.
- */
-function syncFromDom() {
-    if (!isDirtyFlag) return;
-    readEditorIntoState();
-}
+import { setIsCurrentVersion } from '../../editing/editable-state.js';
+import { fileContentRender } from '../ui-functions-render/render-file-content.js';
 
 /**
  * Loads the content of a file, wraps front matter, parses tags and markdown, and then triggers the render.
@@ -72,22 +14,25 @@ export async function loadContentModal(fileToOpen) {
     const fileHandle = appState.myFileHandlesMap.get(fileToOpen);
     const fileChosen = await fileHandle.getFile();
 
+    const raw = await fileChosen.text();
+    const session = appState.editSession;
+
     // On initial load, the active content and live content are identical
-    activeRawContent = await fileChosen.text();
-    liveRawContent = activeRawContent;
-    openContentNormalized = activeRawContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
-    openTextContentLength = openContentNormalized.replace(/\n/g, '').length; // \n → <br> in DOM, invisible to textContent
-    isDirtyFlag = false;
+    session.activeRaw = raw;
+    session.liveRaw = raw;
+    session.openNormalized = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
+    session.openTextLen = session.openNormalized.replace(/\n/g, '').length; // \n → <br> in DOM, invisible to textContent
+    session.isDirty = false;
 
     const fileObj = appState.myFiles.find(f => f.filename === fileToOpen);
     appState.openFileSnapshot = {
         filepath: fileObj?.filepath ?? fileToOpen,
         filename: fileToOpen,
-        content: activeRawContent,
+        content: raw,
     };
 
-    activeHtmlContent = parseContent(activeRawContent);
-    liveHtmlContent = activeHtmlContent;
+    session.activeHtml = parseContent(raw);
+    session.liveHtml = session.activeHtml;
 
     setIsCurrentVersion(true);
     fileContentRender();
@@ -95,155 +40,4 @@ export async function loadContentModal(fileToOpen) {
     await saveBackupEntry(appState.openFileSnapshot, 'open');
     loadHistorySelect(fileToOpen);
     console.log(fileToOpen);
-}
-
-/**
- * Restores the modal to the live file content (undoes any historical selection).
- */
-export function restoreCurrentContent() {
-    activeRawContent = liveRawContent;
-    activeHtmlContent = liveHtmlContent;
-    setIsCurrentVersion(true);
-    fileContentRender();
-}
-
-/**
- * Loads a historical content string into the modal.
- * @param {string} historicalRaw - The raw file text from history to render.
- */
-export function loadHistoricalContent(historicalRaw) {
-    if (getIsCurrentVersion()) {
-        syncFromDom();
-        liveHtmlContent = parseContent(liveRawContent);
-    }
-
-    setIsCurrentVersion(false);
-    activeRawContent = historicalRaw;
-    activeHtmlContent = parseContent(historicalRaw);
-    fileContentRender();
-}
-
-/**
- * Handles the html/txt render toggle and re-parses in-progress edits.
- */
-export function handleToggleRenderText() {
-    if (getIsCurrentVersion()) {
-        syncFromDom(); // appState.editState still holds the outgoing mode here — guard is correct
-        activeHtmlContent = parseContent(activeRawContent);
-        liveHtmlContent = activeHtmlContent;
-    }
-    appState.editState = document.getElementById('render_toggle').checked;
-    fileContentRender();
-}
-
-/**
- * Renders the active content into the modal.
- */
-export function fileContentRender() {
-    const textbox = document.getElementById('modal-content-text');
-    const renderToggle = document.getElementById('render_toggle');
-    renderToggle.checked = appState.editState;
-    const isTxtMode = appState.editState;
-
-    if (isTxtMode) {
-        textbox.innerHTML = '';
-        const preElement = document.createElement('pre');
-        preElement.classList.add('pre-text-enlarge');
-        preElement.classList.add('text-editor');
-        // Only allow editing if we are on the current (live) version
-        preElement.contentEditable = getIsCurrentVersion() ? 'plaintext-only' : 'false';
-        preElement.innerHTML = activeRawContent
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/\r\n|\r|\n/g, '<br>');
-        if (getIsCurrentVersion()) {
-            preElement.dataset.action = 'file-content-edit';
-        }
-        textbox.appendChild(preElement);
-    } else {
-        textbox.innerHTML = activeHtmlContent;
-    }
-
-    // apply search highlights if any
-    highlightPropMatches();
-
-    // apply diff highlights if a prior version
-    if (getIsCurrentVersion()) {
-        clearDiffHighlights();
-    } else {
-        // Compare the historical "active" content against the "live" current version
-        applyDiffHighlights(activeRawContent, liveRawContent);
-    }
-
-    updateUnsavedIndicator();
-}
-
-/**
- * Updates dirty state and the unsaved indicator on each edit.
- * Hot-path design: pre.textContent.length is read on every keystroke because it is
- * non-layout-forcing (raw text nodes only, no CSS). pre.innerText forces a synchronous
- * layout flush and is only read when textContent length matches the open baseline —
- * the rare case where content might have reverted to the original (or a newline was
- * inserted/removed without changing the character count).
- * @param {Event} evt - The input event from the contentEditable pre element.
- */
-export function handleFileContentInput(evt) {
-    scheduleAutosave();
-    const pre = evt.target;
-    if (pre.textContent.length !== openTextContentLength) {
-        // Fast path: length mismatch means content definitely changed — no innerText read needed
-        if (!isDirtyFlag) { isDirtyFlag = true; updateUnsavedIndicator(); }
-        return;
-    }
-    // Slow path: same textContent length — might have reverted; innerText read required
-    liveRawContent = pre.innerText;
-    activeRawContent = liveRawContent;
-    isDirtyFlag = liveRawContent.trimEnd() !== openContentNormalized;
-    updateUnsavedIndicator();
-}
-
-/**
- * Returns true if the live content differs from the content when the modal was opened.
- * @returns {boolean}
- */
-export function hasUnsavedChanges() {
-    return isDirtyFlag;
-}
-
-/**
- * Returns the current live raw text content of the open file.
- * @returns {string}
- */
-export function getLiveRawContent() {
-    return liveRawContent;
-}
-
-/**
- * Resets the saved baseline to the current live content.
- * Called after a successful save so that hasUnsavedChanges() returns false
- * and the unsaved-changes indicator is cleared.
- * @returns {void}
- */
-export function resetUnsavedBaseline() {
-    readEditorIntoState();
-    openContentNormalized = liveRawContent.trimEnd();
-    openTextContentLength = openContentNormalized.replace(/\n/g, '').length;
-    isDirtyFlag = false;
-}
-
-/**
- * Appends a black circle (●) to the filename in the history select button when the
- * current version has unsaved changes, and removes it otherwise.
- * Only shown when viewing the current version — not for historical snapshots.
- * @returns {void}
- */
-export function updateUnsavedIndicator() {
-    const modalContentDiv = document.getElementById("modal-content");
-    const isUnsaved = getIsCurrentVersion() && hasUnsavedChanges();
-    const isCurrent = getIsCurrentVersion();
-    if (modalContentDiv.classList.contains("saved") !== !isUnsaved) {
-        modalContentDiv.classList.toggle("saved", !isUnsaved);
-    }
-    modalContentDiv.classList.toggle("current-version", isCurrent);
 }

--- a/public/js/ui/ui-functions-click/open-file-content-view-trans.js
+++ b/public/js/ui/ui-functions-click/open-file-content-view-trans.js
@@ -2,7 +2,8 @@
 // - the key reason it is so long is because it is controlling a view transition
 // - note if you have lots of html elements on the page (say > 400!) this slows down the view transition
 
-import { loadContentModal, hasUnsavedChanges } from './load-file-content.js';
+import { loadContentModal } from './load-file-content.js';
+import { hasUnsavedChanges } from '../../editing/manage-unsaved-changes.js';
 import { initHistorySelect } from './setup-history-select.js';
 import { appState } from '../../services/store.js';
 import { saveBackupEntry } from '../../editing/local-backup.js';

--- a/public/js/ui/ui-functions-click/save-file-copy.js
+++ b/public/js/ui/ui-functions-click/save-file-copy.js
@@ -2,7 +2,8 @@ import { appState } from '../../services/store.js';
 import { getIsCurrentVersion } from '../../editing/editable-state.js';
 import { decodeModalHtml } from '../../services/file-save.js';
 import { saveFileCopy } from '../../editing/save-file-copy.js';
-import { updateUnsavedIndicator, resetUnsavedBaseline, getLiveRawContent, getEditorElement } from './load-file-content.js';
+import { resetUnsavedBaseline, getLiveRawContent, getEditorElement } from '../../editing/manage-unsaved-changes.js';
+import { updateUnsavedIndicator } from '../ui-functions-render/render-file-content.js';
 import { refreshFileAfterSave } from '../../editing/refresh-file-state.js';
 
 let savePopoverTimer = null;

--- a/public/js/ui/ui-functions-click/setup-history-select.js
+++ b/public/js/ui/ui-functions-click/setup-history-select.js
@@ -1,7 +1,7 @@
 import { appState } from '../../services/store.js';
 import { readBackupHistory } from '../../editing/backup-history-read.js';
 import { renderHistorySelect } from '../ui-functions-render/render-history-select.js';
-import { updateUnsavedIndicator } from './load-file-content.js';
+import { updateUnsavedIndicator } from '../ui-functions-render/render-file-content.js';
 
 /**
  * Resets the history select to show only "current" for a newly opened file.

--- a/public/js/ui/ui-functions-click/toggle-render-text.js
+++ b/public/js/ui/ui-functions-click/toggle-render-text.js
@@ -1,0 +1,19 @@
+import { appState } from '../../services/store.js';
+import { parseContent } from '../../services/parse-content.js';
+import { syncFromDom } from '../../editing/manage-unsaved-changes.js';
+import { getIsCurrentVersion } from '../../editing/editable-state.js';
+import { fileContentRender } from '../ui-functions-render/render-file-content.js';
+
+/**
+ * Handles the html/txt render toggle and re-parses in-progress edits.
+ * @returns {void}
+ */
+export function handleToggleRenderText() {
+    if (getIsCurrentVersion()) {
+        syncFromDom(); // appState.editState still holds the outgoing mode here — guard is correct
+        appState.editSession.activeHtml = parseContent(appState.editSession.activeRaw);
+        appState.editSession.liveHtml = appState.editSession.activeHtml;
+    }
+    appState.editState = document.getElementById('render_toggle').checked;
+    fileContentRender();
+}

--- a/public/js/ui/ui-functions-render/render-file-content.js
+++ b/public/js/ui/ui-functions-render/render-file-content.js
@@ -1,0 +1,65 @@
+import { appState } from '../../services/store.js';
+import { highlightPropMatches } from '../ui-functions-highlight/apply-highlights.js';
+import { applyDiffHighlights, clearDiffHighlights } from '../ui-functions-highlight/diff-highlight.js';
+import { getEditorElement, hasUnsavedChanges } from '../../editing/manage-unsaved-changes.js';
+import { getIsCurrentVersion } from '../../editing/editable-state.js';
+
+/**
+ * Appends a black circle (●) to the filename in the history select button when the
+ * current version has unsaved changes, and removes it otherwise.
+ * Only shown when viewing the current version — not for historical snapshots.
+ * @returns {void}
+ */
+export function updateUnsavedIndicator() {
+    const modalContentDiv = document.getElementById("modal-content");
+    const isUnsaved = getIsCurrentVersion() && hasUnsavedChanges();
+    const isCurrent = getIsCurrentVersion();
+    if (modalContentDiv.classList.contains("saved") !== !isUnsaved) {
+        modalContentDiv.classList.toggle("saved", !isUnsaved);
+    }
+    modalContentDiv.classList.toggle("current-version", isCurrent);
+}
+
+/**
+ * Renders the active content into the modal.
+ * @returns {void}
+ */
+export function fileContentRender() {
+    const textbox = document.getElementById('modal-content-text');
+    const renderToggle = document.getElementById('render_toggle');
+    renderToggle.checked = appState.editState;
+    const isTxtMode = appState.editState;
+
+    if (isTxtMode) {
+        textbox.innerHTML = '';
+        const preElement = document.createElement('pre');
+        preElement.classList.add('pre-text-enlarge');
+        preElement.classList.add('text-editor');
+        // Only allow editing if we are on the current (live) version
+        preElement.contentEditable = getIsCurrentVersion() ? 'plaintext-only' : 'false';
+        preElement.innerHTML = appState.editSession.activeRaw
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\r\n|\r|\n/g, '<br>');
+        if (getIsCurrentVersion()) {
+            preElement.dataset.action = 'file-content-edit';
+        }
+        textbox.appendChild(preElement);
+    } else {
+        textbox.innerHTML = appState.editSession.activeHtml;
+    }
+
+    // apply search highlights if any
+    highlightPropMatches();
+
+    // apply diff highlights if a prior version
+    if (getIsCurrentVersion()) {
+        clearDiffHighlights();
+    } else {
+        // Compare the historical "active" content against the "live" current version
+        applyDiffHighlights(appState.editSession.activeRaw, appState.editSession.liveRaw);
+    }
+
+    updateUnsavedIndicator();
+}


### PR DESCRIPTION
The 250-line file was doing five unrelated things. Split into:
- editing/manage-unsaved-changes.js — tracks whether content has changed since open
- editing/history-navigation.js — switches modal between current and historical versions
- ui-functions-render/render-file-content.js — renders modal content and unsaved indicator
- ui-functions-click/toggle-render-text.js — handles the txt/html mode toggle action
- ui-functions-click/file-content-input.js — handles the contentEditable input event

Content session state (activeRaw, liveRaw, isDirty, etc.) moved to appState.editSession in store.js so the new modules can share it without coupling to each other.

https://claude.ai/code/session_01WQbHGWabvApMqGvPSBxabD