### PR TITLE
Add Settings modal and move colour theme radios into it

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,10 +59,7 @@
       <input type="checkbox" name="fullscreen" id="fullscreen" data-action="toggle-fullscreen">
     </label>
 
-    <div class="color-select-radio">
-      <label class="formcontrol"><input type="radio" name="radio" checked />snow</label>
-      <label class="formcontrol"><input type="radio" name="radio" id="funcheck" />glow</label>
-    </div>
+    <button id="btn-settings" data-action="open-settings-modal">Settings</button>
   </div>
 
   <br><br>
@@ -122,6 +119,48 @@
 
     <div id="output"></div>
   </main>
+
+  <dialog id="modal-settings" data-action="close-settings-outside">
+    <button class="modal-close-btn" data-action="close-settings-modal">✕</button>
+    <h2 class="settings-title">Settings</h2>
+
+    <div class="settings-row">
+      <span class="settings-label">Colour theme</span>
+      <div class="color-select-radio">
+        <label class="formcontrol"><input type="radio" name="radio" checked />snow</label>
+        <label class="formcontrol"><input type="radio" name="radio" id="funcheck" />glow</label>
+      </div>
+    </div>
+
+    <label class="settings-row">
+      <span class="settings-label">Font size (app)</span>
+      <input type="range" min="12" max="24" disabled>
+    </label>
+
+    <label class="settings-row">
+      <span class="settings-label">Font size (text file)</span>
+      <input type="range" min="12" max="32" disabled>
+    </label>
+
+    <label class="settings-row">
+      <span class="settings-label">Font style</span>
+      <select disabled>
+        <option>sans-serif</option>
+        <option>serif</option>
+        <option>monospace</option>
+      </select>
+    </label>
+
+    <label class="settings-row">
+      <span class="settings-label">Pagination size</span>
+      <input type="number" min="10" max="200" disabled>
+    </label>
+
+    <div class="settings-row">
+      <span class="settings-label">Tag autocomplete</span>
+      <label class="switch"><input type="checkbox" disabled><span class="slider"></span></label>
+    </div>
+  </dialog>
 
   <dialog id="modal-unsaved-warning">
     <p>You have unsaved changes</p>

--- a/public/css/modal-settings.css
+++ b/public/css/modal-settings.css
@@ -1,0 +1,53 @@
+#modal-settings {
+    margin: auto;
+    padding: 24px 32px;
+    position: relative;
+    border: 2px solid var(--colour-contr);
+    border-radius: 6px;
+    background-color: var(--colour-neutral-alt);
+    color: var(--colour-contr);
+    min-width: 320px;
+}
+
+#modal-settings::backdrop {
+    background: rgba(0, 0, 0, 0.65);
+}
+
+#modal-settings .settings-title {
+    margin: 0 0 16px;
+    font-size: 1.25em;
+}
+
+#modal-settings .settings-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px 0;
+}
+
+#modal-settings .settings-label {
+    font-weight: 600;
+}
+
+#modal-settings input:disabled,
+#modal-settings select:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#modal-settings .modal-close-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background-color: transparent;
+    border: 1.5px solid transparent;
+    border-radius: 5px;
+    cursor: pointer;
+    color: var(--colour-compl-contr);
+
+    &:hover {
+        border: 1.5px solid var(--colour-compl-contr);
+        box-shadow: var(--hover-box-shadow);
+    }
+}

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -19,6 +19,7 @@ import { handleFilterToggleActive } from './ui-functions-click/filter-toggle-act
 import { handleHistorySelectChange } from './ui-functions-click/history-select-change.js';
 import { handleSaveFileCopy } from './ui-functions-click/save-file-copy.js';
 import { handlePageChange } from './pagination/handle-page-change.js';
+import { handleOpenSettings, handleCloseSettings, handleCloseSettingsOutside } from './ui-functions-click/settings-modal.js';
 
 /**
  * Adds event listeners to the document for click, change, and keyup events.
@@ -49,6 +50,9 @@ const clickActionHandlers = {
     'filter-toggleactive':handleFilterToggleActive,
     'save-file-copy': handleSaveFileCopy,
     'change-page': handlePageChange,
+    'open-settings-modal': handleOpenSettings,
+    'close-settings-modal': handleCloseSettings,
+    'close-settings-outside': handleCloseSettingsOutside,
 };
 
 const changeActionHandlers = {

--- a/public/js/ui/ui-functions-click/settings-modal.js
+++ b/public/js/ui/ui-functions-click/settings-modal.js
@@ -1,0 +1,31 @@
+// Open/close handlers for the Settings modal.
+
+const dialog = document.getElementById('modal-settings');
+
+/**
+ * Opens the Settings modal.
+ * @returns {void}
+ */
+export function handleOpenSettings() {
+    dialog.showModal();
+}
+
+/**
+ * Closes the Settings modal.
+ * @returns {void}
+ */
+export function handleCloseSettings() {
+    dialog.close();
+}
+
+/**
+ * Closes the Settings modal when the user clicks on the backdrop
+ * (i.e. on the dialog element itself rather than any of its children).
+ * @param {Event} event - The click event.
+ * @returns {void}
+ */
+export function handleCloseSettingsOutside(event) {
+    if (event.target === dialog) {
+        dialog.close();
+    }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -22,6 +22,7 @@
 @import url("css/searchbox.css");
 @import url("css/modal-file-content-footer-header.css");
 @import url("css/modal-unsaved-warning.css");
+@import url("css/modal-settings.css");
 @import url("css/modal-history-select.css");
 @import url("css/copy-filename.css");
 @import url("css/radio.css");


### PR DESCRIPTION
Move the snow/glow colour radios out of the page header into a new Settings dialog opened from a header button. The dialog also contains placeholders for font size (app + text file), font style, pagination size, and tag autocomplete - none wired up yet.

Colour switching still works via the existing :has(#funcheck:checked) CSS selector because the inputs remain in the DOM inside the dialog.

https://claude.ai/code/session_01HDNdfXZWYkjoiRhMS8Lcb6