### PR TITLE
Preserve SVG href="#id" attributes in tag substitution

### DIFF
--- a/public/js/services/file-tagparser.js
+++ b/public/js/services/file-tagparser.js
@@ -9,23 +9,29 @@ const tagSet = new Set();
 
 /**
  * Parses a string of text, finds tags (e.g., #tag, #category/tag), and wraps them in HTML `<span>` elements
- * for styling and interaction. It temporarily replaces hex color codes to avoid accidentally parsing them as tags.
+ * for styling and interaction. Skips `#` preceded by `"`, `'`, or `=` (so HTML attribute values like
+ * SVG `href="#id"` survive) and `#` that introduces a hex colour (`#fff`, `#00ff00`).
  *
  * @param {string} text The input text to parse for tags.
  * @returns {string} The text with tags replaced by HTML `<span>` elements.
  */
 export function tagParser(text) {
 	tagSet.clear();
-	
+
 	returnActiveTags(); //mutates tagSet
 
-	const StripHexColors = text.replace(/#(?=([0-9a-fA-F]{3}){1,2}\b)/gm, '%'); // otherwise tagReplace will strip out hex colours like #fff or #00000. Mainly noticeable if using svg
+	// Match #tag and #category/tag, skipping two cases that look like tags but aren't:
+	//   (?<!["'=])  – '#' preceded by a quote or '=' is inside an HTML attribute
+	//                 value (e.g. SVG <use href="#petal"/>) — leave the markup alone.
+	//   (?!(?:[0-9a-fA-F]{3}){1,2}\b)
+	//               – '#' followed by a 3- or 6-char hex sequence is a CSS colour
+	//                 (#fff, #00ff00) — not a tag. Non-capturing so the replacer's
+	//                 p1..p4 positions are unaffected.
+	// Two branches: simple #tag (groups 1-2) and #parent/child (groups 3-4),
+	// matching the structure `tagreplacer` expects.
+	const TAG_REGEX = /(?<!["'=])(#)(?!(?:[0-9a-fA-F]{3}){1,2}\b)(\w+)\b(?!\/)|(?<!["'=])(#\w+\/)(\w+)\b/gm;
 
-	const tagReplace = StripHexColors.replace(/(#)(\w+)\b(?!\/)|(#\w+\/)(\w+)\b/gm, tagreplacer); // replace tags and parents according to function...
-
-	const ReplaceHexColors = tagReplace.replace(/%(?=([0-9a-fA-F]{3}){1,2}\b)/gm, '#'); // put back the hexcodes now the tagReplace is over
-
-	return ReplaceHexColors.trim();
+	return text.replace(TAG_REGEX, tagreplacer).trim();
 }
 
 /**

--- a/tests/17-svg-href-preserved.spec.js
+++ b/tests/17-svg-href-preserved.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require('@playwright/test');
+
+// An inline SVG whose <use> elements reference a <defs> symbol via href="#petal".
+// Before the fix, tagParser rewrote "#petal" into a tag span inside the attribute
+// value, corrupting the SVG so it did not render. The fix excludes '#' preceded
+// by a quote or '=' from tag substitution.
+test('SVG href="#id" attributes are not rewritten as tag spans', async ({ page }) => {
+  await page.addInitScript(() => {
+    const content =
+      '<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">' +
+      '<defs><ellipse id="petal" cx="100" cy="70" rx="15" ry="30" fill="purple"/></defs>' +
+      '<use href="#petal"/>' +
+      '</svg>\n\n' +
+      'A real tag: #realtag\n\n' +
+      'A hex colour: #abcdef\n';
+
+    const makeFile = (name, c) => ({
+      kind: 'file', name,
+      getFile: async () => ({ name, size: c.length, lastModified: Date.now(), text: async () => c }),
+    });
+    window.showDirectoryPicker = async () => ({
+      kind: 'directory', name: 'root',
+      values: async function* () { yield makeFile('rose.md', content); },
+      getFileHandle: async () => { throw new Error('no backup'); },
+    });
+  });
+
+  await page.goto('/');
+  await page.click('[data-click-loadfolder]');
+  await page.locator('.note-grid').first().click();
+  await expect(page.locator('#file-content-modal')).toBeVisible();
+
+  // The <use> element must survive with its href intact.
+  const useHref = await page.evaluate(() =>
+    document.querySelector('#modal-content-text svg use')?.getAttribute('href')
+  );
+  expect(useHref).toBe('#petal');
+
+  // Exactly one tag span should be rendered — from `#realtag`, not `#petal` or `#abcdef`.
+  const tagCount = await page.locator('#modal-content-text .tag').count();
+  expect(tagCount).toBe(1);
+  await expect(page.locator('#modal-content-text .tag').first()).toHaveText(/realtag/);
+});


### PR DESCRIPTION
The `tagParser` was run on raw text before marked(), rewriting any `#foo` into a tag span. This broke inline SVG that used `href="#petal"` to reference a <defs> symbol — the attribute value was corrupted and the SVG failed to render.

Collapse two exclusion cases into one regex:
- negative lookbehind `(?<!["'=])` skips `#` inside attribute values
- negative lookahead `(?!(?:[0-9a-fA-F]{3}){1,2}\b)` skips hex colours

This subsumes the prior strip/restore `%`-swap trick (three string passes → one) and handles SVG attributes at the same time.

https://claude.ai/code/session_01WBPrVxgPjYKtVW8f1FNdjo