### PR TITLE
Add immutable-transaction undo/redo for the plain-text editor

### DIFF
--- a/public/js/editing/undo/apply-change.js
+++ b/public/js/editing/undo/apply-change.js
@@ -1,0 +1,49 @@
+import { appState } from '../../services/store.js';
+import { scheduleAutosave } from '../autosave.js';
+import { fileContentRender } from '../../ui/ui-functions-render/render-file-content.js';
+import { setSelectionAtOffset } from './dom-index-map.js';
+
+/**
+ * @file Applies a ChangeSet to liveRaw/activeRaw, re-renders the editor, and
+ * restores the caret. Also computes the inverse of a change for undo.
+ *
+ * The renderer is called unconditionally — gypsum's notes are small and the
+ * existing architecture already re-renders on every state change. If this
+ * ever becomes a bottleneck on very large files, an incremental DOM-mutation
+ * fast path can be added without touching the calling code.
+ */
+
+/**
+ * Splices the change into liveRaw/activeRaw, re-renders the editor, restores
+ * the caret at `caretAt`, updates dirty/unsaved indicator, and schedules autosave.
+ * @param {{from: number, to: number, insert: string}} change
+ * @param {number} caretAt - character index at which to place the caret after re-render.
+ * @returns {void}
+ */
+export function applyChange(change, caretAt) {
+    const session = appState.editSession;
+    const next = session.liveRaw.slice(0, change.from) + change.insert + session.liveRaw.slice(change.to);
+    session.liveRaw = next;
+    session.activeRaw = next;
+    session.isDirty = next.trimEnd() !== session.openNormalized;
+
+    fileContentRender();  // also calls updateUnsavedIndicator internally
+
+    const preEl = document.querySelector('#modal-content-text .text-editor');
+    if (preEl) setSelectionAtOffset(preEl, caretAt);
+
+    scheduleAutosave();
+}
+
+/**
+ * Returns the inverse of a change given the text that was removed.
+ * @param {{from: number, to: number, insert: string, removed: string}} change
+ * @returns {{from: number, to: number, insert: string}}
+ */
+export function invertChange(change) {
+    return {
+        from: change.from,
+        to: change.from + change.insert.length,
+        insert: change.removed,
+    };
+}

--- a/public/js/editing/undo/beforeinput-capture.js
+++ b/public/js/editing/undo/beforeinput-capture.js
@@ -1,0 +1,102 @@
+import { appState } from '../../services/store.js';
+import { rangeToOffsets, selectionToOffsets } from './dom-index-map.js';
+import { applyChange } from './apply-change.js';
+import { pushTransaction } from './undo-state.js';
+
+/**
+ * @file Turns a `beforeinput` event on the editor into an immutable
+ * Transaction. Runs in the capture phase via the document delegate in
+ * event-listeners-add.js so preventDefault() fires before the browser mutates
+ * the DOM (which also suppresses the subsequent `input` event, keeping
+ * file-content-input.js out of the loop for captured edits).
+ *
+ * Non-captured paths (e.g. IME composition, which cannot be safely
+ * preventDefault-ed) fall through to the existing `input` handler.
+ */
+
+const ATOMIC_TYPES = new Set(['insertFromPaste', 'deleteByCut', 'insertReplacementText', 'insertFromDrop']);
+
+/**
+ * @param {InputEvent} evt
+ * @returns {void}
+ */
+export function handleBeforeInput(evt) {
+    if (evt.isComposing) return;  // let IME composition through to native
+    const preEl = evt.target.closest('[data-action="file-content-edit"]');
+    if (!preEl) return;
+
+    const offsets = extractOffsets(evt, preEl);
+    if (!offsets) return;
+
+    const insert = extractInsertText(evt);
+    const resolvedInsert = (evt.inputType === 'insertLineBreak' || evt.inputType === 'insertParagraph')
+        ? (insert || '\n')
+        : insert;
+    const { from, to } = offsets;
+    const removed = appState.editSession.liveRaw.slice(from, to);
+
+    // Filter no-ops: cursor-only events, or deletes/inserts that change nothing.
+    if (from === to && resolvedInsert === '') return;
+    if (resolvedInsert === removed) return;
+
+    evt.preventDefault();
+
+    const type = normalizeType(evt.inputType, from !== to);
+    const change = { from, to, insert: resolvedInsert, removed };
+    const caretAt = from + resolvedInsert.length;
+
+    const tx = {
+        change,
+        selectionBefore: { from, to },
+        selectionAfter:  { from: caretAt, to: caretAt },
+        type,
+        time: Date.now(),
+    };
+
+    applyChange(change, caretAt);
+    pushTransaction(tx);
+}
+
+/**
+ * Derives { from, to } offsets from the event, preferring getTargetRanges().
+ * @param {InputEvent} evt
+ * @param {HTMLElement} preEl
+ * @returns {{from: number, to: number}|null}
+ */
+function extractOffsets(evt, preEl) {
+    const targets = typeof evt.getTargetRanges === 'function' ? evt.getTargetRanges() : [];
+    if (targets && targets.length > 0) {
+        const off = rangeToOffsets(targets[0], preEl);
+        if (off) return off;
+    }
+    return selectionToOffsets(preEl);
+}
+
+/**
+ * Returns the text to be inserted by this event.
+ * @param {InputEvent} evt
+ * @returns {string}
+ */
+function extractInsertText(evt) {
+    if (evt.data != null) return evt.data;
+    if (evt.dataTransfer) {
+        const plain = evt.dataTransfer.getData('text/plain');
+        if (plain) return plain;
+    }
+    return '';
+}
+
+/**
+ * Collapses inputType into one of the grouping categories used by undo-state.
+ * Any delete whose source range is non-collapsed is treated as atomic.
+ * @param {string} inputType
+ * @param {boolean} hasSelectionRange
+ * @returns {string}
+ */
+function normalizeType(inputType, hasSelectionRange) {
+    if (ATOMIC_TYPES.has(inputType)) return inputType;
+    if (inputType === 'insertText') return 'insertText';
+    if (inputType === 'deleteContentBackward' && !hasSelectionRange) return 'deleteContentBackward';
+    if (inputType === 'insertLineBreak' || inputType === 'insertParagraph') return 'insertLineBreak';
+    return inputType || 'atomic';
+}

--- a/public/js/editing/undo/dom-index-map.js
+++ b/public/js/editing/undo/dom-index-map.js
@@ -1,0 +1,170 @@
+/**
+ * @file Pure DOM<->character-index utilities for the `<pre>` editor.
+ *
+ * The editor's innerHTML is an alternating sequence of escaped text nodes and
+ * `<br>` elements (fileContentRender() emits this shape). A character index
+ * into liveRaw is: sum of preceding text-node lengths, plus one per preceding
+ * `<br>`. These helpers translate between that flat index and DOM (node,
+ * offset) positions.
+ */
+
+/**
+ * Converts a StaticRange (from beforeinput.getTargetRanges()) into character
+ * offsets in liveRaw. Returns null if the range's containers are outside preEl.
+ * @param {StaticRange|Range} range
+ * @param {HTMLElement} preEl
+ * @returns {{from: number, to: number}|null}
+ */
+export function rangeToOffsets(range, preEl) {
+    const from = nodeOffsetToIndex(range.startContainer, range.startOffset, preEl);
+    const to = nodeOffsetToIndex(range.endContainer, range.endOffset, preEl);
+    if (from === null || to === null) return null;
+    return { from, to };
+}
+
+/**
+ * Reads the current window selection as liveRaw offsets.
+ * @param {HTMLElement} preEl
+ * @returns {{from: number, to: number}|null}
+ */
+export function selectionToOffsets(preEl) {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return null;
+    const r = sel.getRangeAt(0);
+    if (!preEl.contains(r.startContainer) || !preEl.contains(r.endContainer)) return null;
+    return rangeToOffsets(r, preEl);
+}
+
+/**
+ * Places the caret at a flat character offset within preEl.
+ * @param {HTMLElement} preEl
+ * @param {number} offset
+ * @returns {void}
+ */
+export function setSelectionAtOffset(preEl, offset) {
+    setSelectionRange(preEl, offset, offset);
+}
+
+/**
+ * Places the selection spanning [from, to] within preEl.
+ * @param {HTMLElement} preEl
+ * @param {number} from
+ * @param {number} to
+ * @returns {void}
+ */
+export function setSelectionRange(preEl, from, to) {
+    const start = indexToNodeOffset(preEl, from);
+    const end = from === to ? start : indexToNodeOffset(preEl, to);
+    if (!start || !end) return;
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+/**
+ * @param {Node} node
+ * @returns {number}
+ */
+function flatLength(node) {
+    if (node.nodeType === Node.TEXT_NODE) return node.data.length;
+    if (node.nodeName === 'BR') return 1;
+    return (node.textContent || '').length;
+}
+
+/**
+ * Converts a (container, offset) position to a flat index into liveRaw.
+ * Container may be a text node (offset = character index), preEl (offset =
+ * childNode boundary index), or a nested element (rare; walk it).
+ * @param {Node} container
+ * @param {number} offset
+ * @param {HTMLElement} preEl
+ * @returns {number|null}
+ */
+function nodeOffsetToIndex(container, offset, preEl) {
+    if (container === preEl) {
+        let index = 0;
+        for (let i = 0; i < offset && i < preEl.childNodes.length; i++) {
+            index += flatLength(preEl.childNodes[i]);
+        }
+        return index;
+    }
+    if (!preEl.contains(container)) return null;
+
+    let index = 0;
+    for (const child of preEl.childNodes) {
+        if (child === container) {
+            return index + offset;
+        }
+        if (child.nodeType === Node.ELEMENT_NODE && child.contains(container)) {
+            return index + offsetWithinElement(child, container, offset);
+        }
+        index += flatLength(child);
+    }
+    return null;
+}
+
+/**
+ * Walks a nested element subtree summing text/BR lengths until `target` is
+ * reached, then adds `offset`.
+ * @param {Element} root
+ * @param {Node} target
+ * @param {number} offset
+ * @returns {number}
+ */
+function offsetWithinElement(root, target, offset) {
+    let index = 0;
+    function walk(node) {
+        if (node === target) {
+            index += offset;
+            return true;
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+            index += node.data.length;
+            return false;
+        }
+        if (node.nodeName === 'BR') {
+            index += 1;
+            return false;
+        }
+        for (const child of node.childNodes) {
+            if (walk(child)) return true;
+        }
+        return false;
+    }
+    walk(root);
+    return index;
+}
+
+/**
+ * Converts a flat character index into (node, offset) inside preEl. Prefers
+ * text-node positions; uses preEl-level offsets adjacent to `<br>` elements.
+ * @param {HTMLElement} preEl
+ * @param {number} target
+ * @returns {{node: Node, offset: number}|null}
+ */
+function indexToNodeOffset(preEl, target) {
+    let index = 0;
+    const children = preEl.childNodes;
+    for (let i = 0; i < children.length; i++) {
+        const child = children[i];
+        if (child.nodeType === Node.TEXT_NODE) {
+            const len = child.data.length;
+            if (target <= index + len) {
+                return { node: child, offset: target - index };
+            }
+            index += len;
+        } else if (child.nodeName === 'BR') {
+            if (target === index) return { node: preEl, offset: i };
+            index += 1;
+            if (target === index) return { node: preEl, offset: i + 1 };
+        } else {
+            const len = (child.textContent || '').length;
+            if (target <= index + len) return { node: preEl, offset: i };
+            index += len;
+        }
+    }
+    return { node: preEl, offset: preEl.childNodes.length };
+}

--- a/public/js/editing/undo/undo-redo.js
+++ b/public/js/editing/undo/undo-redo.js
@@ -1,0 +1,48 @@
+import { popUndo, popRedo } from './undo-state.js';
+import { applyChange, invertChange } from './apply-change.js';
+import { setSelectionRange } from './dom-index-map.js';
+
+/**
+ * @file User-facing undo/redo operations. Invoked from the keydown delegate
+ * when Mod-Z / Mod-Y / Shift-Mod-Z fires inside the editor. No-op silently
+ * when the respective stack is empty.
+ */
+
+/**
+ * Pops the tail of `done`, applies its inverse, and restores selectionBefore.
+ * @returns {boolean} true if an undo was applied.
+ */
+export function performUndo() {
+    const tx = popUndo();
+    if (!tx) return false;
+
+    const inverse = invertChange(tx.change);
+    applyChange(inverse, tx.selectionBefore.from);
+    restoreSelection(tx.selectionBefore);
+    return true;
+}
+
+/**
+ * Pops the tail of `undone`, re-applies the original change, and restores
+ * selectionAfter.
+ * @returns {boolean} true if a redo was applied.
+ */
+export function performRedo() {
+    const tx = popRedo();
+    if (!tx) return false;
+
+    applyChange(tx.change, tx.selectionAfter.from);
+    restoreSelection(tx.selectionAfter);
+    return true;
+}
+
+/**
+ * Restores a non-collapsed selection after applyChange placed the caret.
+ * @param {{from: number, to: number}} sel
+ * @returns {void}
+ */
+function restoreSelection(sel) {
+    if (sel.from === sel.to) return;  // caret already placed by applyChange
+    const preEl = document.querySelector('#modal-content-text .text-editor');
+    if (preEl) setSelectionRange(preEl, sel.from, sel.to);
+}

--- a/public/js/editing/undo/undo-state.js
+++ b/public/js/editing/undo/undo-state.js
@@ -1,0 +1,127 @@
+import { appState } from '../../services/store.js';
+
+/**
+ * @file Owns the done/undone stacks on appState.editSession.undo.
+ * Applies the 500ms same-type adjacent-boundary grouping rule when pushing
+ * new transactions, clears the redo stack on any new user edit (Truncation
+ * Rule), and exposes simple pop helpers for performUndo / performRedo.
+ */
+
+const GROUP_WINDOW_MS = 500;
+const GROUPABLE_TYPES = new Set(['insertText', 'deleteContentBackward']);
+
+/**
+ * Empties both stacks and resets grouping metadata. Called on file open.
+ * @returns {void}
+ */
+export function resetUndoStacks() {
+    const undo = appState.editSession.undo;
+    undo.done.length = 0;
+    undo.undone.length = 0;
+    undo.lastEditAt = 0;
+    undo.lastType = null;
+}
+
+/**
+ * Pushes a transaction onto `done`, clearing `undone` first (Truncation Rule),
+ * and merges with the previous tail when the 500ms same-type adjacent-boundary
+ * rule is satisfied. Atomic transactions (paste/cut/selection-delete) never merge.
+ * @param {object} tx - Transaction with { change, selectionBefore, selectionAfter, type, time }.
+ * @returns {void}
+ */
+export function pushTransaction(tx) {
+    const undo = appState.editSession.undo;
+    undo.undone.length = 0;
+
+    const tail = undo.done[undo.done.length - 1];
+    if (tail && canMerge(tail, tx, undo)) {
+        undo.done[undo.done.length - 1] = mergeTransactions(tail, tx);
+    } else {
+        undo.done.push(tx);
+    }
+
+    undo.lastEditAt = tx.time;
+    undo.lastType = tx.type;
+}
+
+/**
+ * Moves the top transaction from `done` to `undone` and returns it.
+ * @returns {object|null}
+ */
+export function popUndo() {
+    const undo = appState.editSession.undo;
+    const tx = undo.done.pop();
+    if (!tx) return null;
+    undo.undone.push(tx);
+    // A subsequent edit should not merge with the now-popped tail.
+    undo.lastEditAt = 0;
+    undo.lastType = null;
+    return tx;
+}
+
+/**
+ * Moves the top transaction from `undone` back to `done` and returns it.
+ * @returns {object|null}
+ */
+export function popRedo() {
+    const undo = appState.editSession.undo;
+    const tx = undo.undone.pop();
+    if (!tx) return null;
+    undo.done.push(tx);
+    undo.lastEditAt = 0;
+    undo.lastType = null;
+    return tx;
+}
+
+/**
+ * Returns true if `next` can be merged into `prev`'s transaction tail.
+ * @param {object} prev
+ * @param {object} next
+ * @param {object} undo - appState.editSession.undo
+ * @returns {boolean}
+ */
+function canMerge(prev, next, undo) {
+    if (!GROUPABLE_TYPES.has(next.type)) return false;
+    if (prev.type !== next.type) return false;
+    if (next.time - undo.lastEditAt >= GROUP_WINDOW_MS) return false;
+
+    const p = prev.change;
+    const n = next.change;
+    if (next.type === 'insertText') {
+        // Previous insert ended at index `p.to + p.insert.length`; next insert
+        // should start exactly there.
+        return n.from === p.from + p.insert.length && p.from === p.to && n.from === n.to;
+    }
+    if (next.type === 'deleteContentBackward') {
+        // Consecutive backward deletes: the new delete ends where the previous one started.
+        return n.to === p.from;
+    }
+    return false;
+}
+
+/**
+ * Merges two same-type transactions into one, keeping earliest selectionBefore
+ * and latest selectionAfter.
+ * @param {object} prev
+ * @param {object} next
+ * @returns {object}
+ */
+function mergeTransactions(prev, next) {
+    const p = prev.change;
+    const n = next.change;
+    let merged;
+    if (next.type === 'insertText') {
+        merged = { from: p.from, to: p.to, insert: p.insert + n.insert, removed: '' };
+    } else {
+        // Backward delete: `next` removes text immediately left of `prev`'s range.
+        // Combined range [n.from, p.to); combined removed = n.removed + p.removed (document order).
+        merged = { from: n.from, to: p.to, insert: '', removed: n.removed + p.removed };
+    }
+    return {
+        change: merged,
+        selectionBefore: prev.selectionBefore,
+        selectionAfter: next.selectionAfter,
+        type: next.type,
+        time: next.time,
+    };
+}

--- a/public/js/services/store.js
+++ b/public/js/services/store.js
@@ -52,6 +52,12 @@ export const appState = {
     openNormalized: '',   // \r\n-unified, trimEnd baseline set on file open
     openTextLen:    0,    // length of openNormalized without \n chars (fast-path gate)
     isDirty:        false,
+    undo: {
+      done:       [],     // Transaction[] — tail is most recent
+      undone:     [],     // Transaction[] — cleared on any new user edit
+      lastEditAt: 0,      // ms timestamp of the tail of `done` for 500ms grouping
+      lastType:   null,   // 'insertText' | 'deleteContentBackward' | null
+    },
   },
 
   dirHandle: null,       // FileSystemDirectoryHandle — set by directory loader, null otherwise

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -21,6 +21,8 @@ import { handleHistorySelectChange } from './ui-functions-click/history-select-c
 import { handleSaveFileCopy } from './ui-functions-click/save-file-copy.js';
 import { handlePageChange } from './pagination/handle-page-change.js';
 import { handleOpenSettings, handleCloseSettings, handleCloseSettingsOutside } from './ui-functions-click/settings-modal.js';
+import { handleBeforeInput } from '../editing/undo/beforeinput-capture.js';
+import { performUndo, performRedo } from '../editing/undo/undo-redo.js';
 
 /**
  * Adds event listeners to the document for click, change, and keyup events.
@@ -32,6 +34,10 @@ export function addActionHandlers() {
     document.addEventListener("keydown", keyDownDelegate);
     document.addEventListener("keyup", keyUpDelegate);
     document.addEventListener("input", inputDelegate);
+    // Capture phase: preventDefault() must fire before the browser mutates the
+    // contenteditable DOM, which also suppresses the subsequent `input` event
+    // so file-content-input.js doesn't double-process captured edits.
+    document.addEventListener("beforeinput", beforeInputDelegate, true);
 }
 
 // Map 'data-action' names from html to their handler functions.
@@ -72,6 +78,10 @@ const keyUpActionHandlers = {
 
 const inputActionHandlers = {
     'file-content-edit': handleFileContentInput,
+};
+
+const beforeInputActionHandlers = {
+    'file-content-edit': handleBeforeInput,
 };
 
 /**
@@ -118,9 +128,23 @@ function changeDelegate(evt) {
  * @param {KeyboardEvent} evt
  */
 function keyDownDelegate(evt) {
-    if ((evt.ctrlKey || evt.metaKey) && evt.key === 's') {
-        evt.preventDefault();
-        handleSaveFileCopy();
+    if (evt.ctrlKey || evt.metaKey) {
+        if (evt.key === 's') {
+            evt.preventDefault();
+            handleSaveFileCopy();
+            return;
+        }
+        // Undo/redo only when the active target is the plain-text editor.
+        const inEditor = evt.target?.closest?.('[data-action="file-content-edit"]');
+        if (!inEditor) return;
+        const key = evt.key.toLowerCase();
+        if (key === 'z' && !evt.shiftKey) {
+            evt.preventDefault();
+            performUndo();
+        } else if (key === 'y' || (key === 'z' && evt.shiftKey)) {
+            evt.preventDefault();
+            performRedo();
+        }
     }
 }
 
@@ -153,6 +177,24 @@ function inputDelegate(evt) {
     if (actionElement) {
         const actionName = actionElement.dataset.action;
         const handler = inputActionHandlers[actionName];
+
+        if (handler) {
+            handler(evt, actionElement);
+        }
+    }
+}
+
+/**
+ * Handles all beforeinput events on the document (capture phase) and
+ * delegates to the appropriate handler via the element's data-action.
+ * @param {InputEvent} evt
+ */
+function beforeInputDelegate(evt) {
+    const actionElement = evt.target?.closest?.('[data-action]');
+
+    if (actionElement) {
+        const actionName = actionElement.dataset.action;
+        const handler = beforeInputActionHandlers[actionName];
 
         if (handler) {
             handler(evt, actionElement);

--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -4,6 +4,7 @@ import { saveBackupEntry } from '../../editing/local-backup.js';
 import { loadHistorySelect } from './setup-history-select.js';
 import { setIsCurrentVersion } from '../../editing/editable-state.js';
 import { fileContentRender } from '../ui-functions-render/render-file-content.js';
+import { resetUndoStacks } from '../../editing/undo/undo-state.js';
 
 /**
  * Loads the content of a file, wraps front matter, parses tags and markdown, and then triggers the render.
@@ -23,6 +24,7 @@ export async function loadContentModal(fileToOpen) {
     session.openNormalized = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
     session.openTextLen = session.openNormalized.replace(/\n/g, '').length; // \n → <br> in DOM, invisible to textContent
     session.isDirty = false;
+    resetUndoStacks();
 
     const fileObj = appState.myFiles.find(f => f.filename === fileToOpen);
     appState.openFileSnapshot = {

--- a/tests/18-undo-redo.spec.js
+++ b/tests/18-undo-redo.spec.js
@@ -1,0 +1,227 @@
+const { test, expect } = require('@playwright/test');
+const { setupMockDirectoryWithHistory, setupMockDirectoryWithSaveSupport } = require('./helpers');
+
+async function waitForHistoryOptions(page, count) {
+  await page.waitForFunction((n) => {
+    const sel = document.getElementById('file-content-history-select');
+    return sel && sel.options.length >= n;
+  }, count);
+}
+
+async function openModal(page) {
+  await page.click('[data-click-loadfolder]');
+  await page.locator('.note-grid').first().click();
+  await expect(page.locator('#file-content-modal')).toBeVisible();
+  await waitForHistoryOptions(page, 1);
+}
+
+async function switchToTxt(page) {
+  await page.evaluate(() => {
+    const t = document.getElementById('render_toggle');
+    if (!t.checked) t.click();
+  });
+  await expect(page.locator('#modal-content-text pre')).toBeVisible();
+}
+
+async function switchToHtml(page) {
+  await page.evaluate(() => {
+    const t = document.getElementById('render_toggle');
+    if (t.checked) t.click();
+  });
+}
+
+// Places caret at end of the <pre>, focusing it.
+async function focusAtEnd(page) {
+  await page.evaluate(() => {
+    const pre = document.querySelector('#modal-content-text .text-editor');
+    pre.focus();
+    const range = document.createRange();
+    range.selectNodeContents(pre);
+    range.collapse(false);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+async function readEditorText(page) {
+  return await page.evaluate(() => {
+    const pre = document.querySelector('#modal-content-text .text-editor');
+    return pre ? pre.innerText : null;
+  });
+}
+
+async function readLiveRaw(page) {
+  return await page.evaluate(() => window.appState.editSession.liveRaw);
+}
+
+async function undoCount(page) {
+  return await page.evaluate(() => window.appState.editSession.undo.done.length);
+}
+
+async function redoCount(page) {
+  return await page.evaluate(() => window.appState.editSession.undo.undone.length);
+}
+
+test.describe('Undo/redo in the plain-text editor', () => {
+
+  test('single-character typing: Ctrl+Z unwinds, Ctrl+Y redoes', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await focusAtEnd(page);
+
+    const before = await readLiveRaw(page);
+
+    await page.keyboard.type('XYZ', { delay: 50 });
+    expect(await readLiveRaw(page)).toBe(before + 'XYZ');
+
+    // Within the 500ms grouping window — the three chars should merge.
+    expect(await undoCount(page)).toBe(1);
+
+    await page.keyboard.press('Control+z');
+    expect(await readLiveRaw(page)).toBe(before);
+
+    await page.keyboard.press('Control+y');
+    expect(await readLiveRaw(page)).toBe(before + 'XYZ');
+  });
+
+  test('temporal grouping boundary: 600ms pause splits transactions', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await focusAtEnd(page);
+
+    const before = await readLiveRaw(page);
+
+    await page.keyboard.type('abc', { delay: 20 });
+    await page.waitForTimeout(600);
+    await page.keyboard.type('def', { delay: 20 });
+
+    expect(await readLiveRaw(page)).toBe(before + 'abcdef');
+    expect(await undoCount(page)).toBe(2);
+
+    await page.keyboard.press('Control+z');
+    expect(await readLiveRaw(page)).toBe(before + 'abc');
+
+    await page.keyboard.press('Control+z');
+    expect(await readLiveRaw(page)).toBe(before);
+  });
+
+  test('new edit after undo clears the redo stack', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await focusAtEnd(page);
+
+    const before = await readLiveRaw(page);
+
+    await page.keyboard.type('abc', { delay: 20 });
+    await page.keyboard.press('Control+z');
+    expect(await redoCount(page)).toBe(1);
+
+    await page.keyboard.type('x');
+    expect(await redoCount(page)).toBe(0);
+
+    // Ctrl+Y should now be inert.
+    const afterTyping = await readLiveRaw(page);
+    await page.keyboard.press('Control+y');
+    expect(await readLiveRaw(page)).toBe(afterTyping);
+
+    expect(afterTyping).toBe(before + 'x');
+  });
+
+  test('undo stack survives txt->html->txt toggle', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await focusAtEnd(page);
+
+    const before = await readLiveRaw(page);
+
+    await page.keyboard.type('Hello', { delay: 20 });
+    expect(await undoCount(page)).toBe(1);
+
+    await switchToHtml(page);
+    await switchToTxt(page);
+
+    // Stacks preserved across mode toggle.
+    expect(await undoCount(page)).toBe(1);
+
+    await focusAtEnd(page);
+    await page.keyboard.press('Control+z');
+    expect(await readLiveRaw(page)).toBe(before);
+  });
+
+  test('undo stack survives a historical version round-trip', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await waitForHistoryOptions(page, 3);
+
+    await switchToTxt(page);
+    await focusAtEnd(page);
+    const before = await readLiveRaw(page);
+
+    await page.keyboard.type('NEW', { delay: 20 });
+    expect(await undoCount(page)).toBe(1);
+
+    // Browse a historical version.
+    await page.selectOption('#file-content-history-select', { index: 2 });
+    expect(await undoCount(page)).toBe(1);  // stacks untouched during pause
+
+    // Back to current.
+    await page.selectOption('#file-content-history-select', { value: 'current' });
+    expect(await undoCount(page)).toBe(1);
+
+    await focusAtEnd(page);
+    await page.keyboard.press('Control+z');
+    expect(await readLiveRaw(page)).toBe(before);
+  });
+
+  test('opening a different file clears the undo stack', async ({ page }) => {
+    await setupMockDirectoryWithSaveSupport(page);
+    await page.goto('/');
+    await page.click('[data-click-loadfolder]');
+
+    // Open notes.md, type, confirm one transaction.
+    await page.locator('.note-grid').first().click();
+    await expect(page.locator('#file-content-modal')).toBeVisible();
+    await switchToTxt(page);
+    await focusAtEnd(page);
+    await page.keyboard.type('mutation', { delay: 20 });
+    expect(await undoCount(page)).toBeGreaterThan(0);
+
+    // Close modal and re-open — simulates opening the same file afresh,
+    // which calls loadContentModal → resetUndoStacks().
+    await page.keyboard.press('Escape');
+    // The unsaved-changes dialog may intercept; discard.
+    const discard = page.locator('[data-action="discard-modal-changes"]');
+    if (await discard.isVisible().catch(() => false)) {
+      await discard.click();
+    }
+    await page.locator('.note-grid').first().click();
+    await expect(page.locator('#file-content-modal')).toBeVisible();
+
+    expect(await undoCount(page)).toBe(0);
+    expect(await redoCount(page)).toBe(0);
+  });
+
+  test('Ctrl+Z on an empty stack is inert', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await focusAtEnd(page);
+
+    const before = await readLiveRaw(page);
+    await page.keyboard.press('Control+z');
+    expect(await readLiveRaw(page)).toBe(before);
+    expect(await undoCount(page)).toBe(0);
+  });
+
+});


### PR DESCRIPTION
Captures edits at beforeinput time using getTargetRanges() + event.data to build ChangeSets, maintains done/undone stacks on appState.editSession.undo, and overrides native Ctrl+Z/Y/Shift+Z via the existing delegated keydown handler. Consecutive insertText or deleteContentBackward events within 500ms and at adjacent boundaries are grouped into a single transaction; paste/cut/selection-delete are atomic. Stacks are preserved (shortcuts inert) while the user toggles to html mode or browses historical snapshots, and reset on new file open. Adds tests/18-undo-redo.spec.js covering typing, grouping, redo-stack truncation, mode-toggle / history round-trips, and cross-file reset.

https://claude.ai/code/session_01LCEUaBcJaC9gXq6ceR4xs5