### PR TITLE
Apply SVG attribute exclusion to tag-index regex

### DIFF
--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -8,8 +8,10 @@ export const COPYATTR = "filename";
 // pattern matching when parsing files
 // match the text on a line that starts with '# ' - grp 1
 export const regex_title = /(?<=^# )(.*$)/;
-// grp 1 - the whole #string, grp 2 - the parent text (if exists), grp 3 - the tag text. Note the negative lookahead to avoid returning hex colours like #fff etc
-export const regex_tag = /#(?!([0-9a-fA-F]{3}){1,2}\b)(?:(\w+)\/)?(\w+)/;
+// grp 1 - the whole #string, grp 2 - the parent text (if exists), grp 3 - the tag text.
+// Negative lookbehind skips '#' preceded by '"', "'" or '=' (HTML attribute values like SVG href="#id").
+// Negative lookahead skips hex colours (#fff, #00ff00).
+export const regex_tag = /(?<!["'=])#(?!([0-9a-fA-F]{3}){1,2}\b)(?:(\w+)\/)?(\w+)/;
 
 export const VIEWS = {
     TABLE: { value: "table", label: "table view" },

--- a/tests/17-svg-href-preserved.spec.js
+++ b/tests/17-svg-href-preserved.spec.js
@@ -1,10 +1,10 @@
 const { test, expect } = require('@playwright/test');
 
-// An inline SVG whose <use> elements reference a <defs> symbol via href="#petal".
-// Before the fix, tagParser rewrote "#petal" into a tag span inside the attribute
-// value, corrupting the SVG so it did not render. The fix excludes '#' preceded
-// by a quote or '=' from tag substitution.
-test('SVG href="#id" attributes are not rewritten as tag spans', async ({ page }) => {
+// Mock a file whose body contains inline SVG (with href="#petal"), a real tag,
+// and a hex colour. Two separate tag-matching paths need to ignore `#petal`:
+//   1. tagParser (render-time) — injects <span class="tag"> into rendered HTML
+//   2. regex_tag in file-info.js (load-time) — builds file.tags Map for filters
+async function loadRoseFile(page) {
   await page.addInitScript(() => {
     const content =
       '<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">' +
@@ -27,6 +27,11 @@ test('SVG href="#id" attributes are not rewritten as tag spans', async ({ page }
 
   await page.goto('/');
   await page.click('[data-click-loadfolder]');
+  await expect(page.locator('.note-grid')).toHaveCount(1);
+}
+
+test('SVG href="#id" attributes are not rewritten as tag spans', async ({ page }) => {
+  await loadRoseFile(page);
   await page.locator('.note-grid').first().click();
   await expect(page.locator('#file-content-modal')).toBeVisible();
 
@@ -40,4 +45,17 @@ test('SVG href="#id" attributes are not rewritten as tag spans', async ({ page }
   const tagCount = await page.locator('#modal-content-text .tag').count();
   expect(tagCount).toBe(1);
   await expect(page.locator('#modal-content-text .tag').first()).toHaveText(/realtag/);
+});
+
+test('SVG href="#id" is not harvested into the file.tags index', async ({ page }) => {
+  await loadRoseFile(page);
+
+  const tagKeys = await page.evaluate(() => {
+    const file = window.appState.myFiles.find(f => f.filename === 'rose.md');
+    return [...file.tags.keys()];
+  });
+
+  expect(tagKeys).toContain('realtag');
+  expect(tagKeys).not.toContain('petal');
+  expect(tagKeys).not.toContain('abcdef');
 });


### PR DESCRIPTION
The prior fix updated the render-time tag regex in file-tagparser.js but not the separate regex_tag constant in constants.js, which is used by file-info.js to scan raw file content and populate each file's tags Map (the filter/sidebar index). As a result SVGs rendered correctly but `#petal` inside `<use href="#petal">` still appeared as a phantom tag on the file.

Add the same `(?<!["'=])` negative lookbehind to regex_tag so both regexes share one exclusion policy. Extend the SVG test to assert that the harvested file.tags index contains `realtag` but not `petal` or `abcdef`.

https://claude.ai/code/session_01WBPrVxgPjYKtVW8f1FNdjo