### PR TITLE
Fix caret drift on CRLF files by normalising line endings on load

### DIFF
--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -16,12 +16,17 @@ export async function loadContentModal(fileToOpen) {
     const fileChosen = await fileHandle.getFile();
 
     const raw = await fileChosen.text();
+    // Normalise line endings on load: the DOM collapses every CRLF to a single
+    // <br>, so liveRaw must use the same \n-only convention or character
+    // offsets between the DOM and the buffer drift by the count of preceding
+    // \r\n sequences.
+    const normalized = raw.replace(/\r\n|\r/g, '\n');
     const session = appState.editSession;
 
     // On initial load, the active content and live content are identical
-    session.activeRaw = raw;
-    session.liveRaw = raw;
-    session.openNormalized = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
+    session.activeRaw = normalized;
+    session.liveRaw = normalized;
+    session.openNormalized = normalized.trimEnd();
     session.openTextLen = session.openNormalized.replace(/\n/g, '').length; // \n → <br> in DOM, invisible to textContent
     session.isDirty = false;
     resetUndoStacks();

--- a/tests/18-undo-redo.spec.js
+++ b/tests/18-undo-redo.spec.js
@@ -304,4 +304,40 @@ test.describe('Undo/redo in the plain-text editor', () => {
     expect(await undoCount(page)).toBe(0);
   });
 
+  test('typing in a CRLF file inserts at the caret, not offset left', async ({ page }) => {
+    // Regression: liveRaw previously kept literal \r\n (2 chars per line
+    // break) while the DOM collapsed each \r\n to a single <br> (1 char).
+    // nodeOffsetToIndex() under-counted by N (the number of \r\n before
+    // the caret), so splices landed N positions too far left.
+    await page.addInitScript(() => {
+      const content = '---\r\ntitle: Test\r\ntag: x\r\n---\r\n\r\nBody line one\r\nBody line two';
+      const makeFile = (name, c) => ({
+        kind: 'file', name,
+        getFile: async () => ({ name, size: c.length, lastModified: Date.now(), text: async () => c }),
+      });
+      window.showDirectoryPicker = async () => ({
+        kind: 'directory', name: 'root',
+        values: async function* () { yield makeFile('notes.md', content); },
+        getFileHandle: async () => { throw new Error('no backup'); },
+      });
+    });
+    await page.goto('/');
+    await page.click('[data-click-loadfolder]');
+    await page.locator('.note-grid').first().click();
+    await expect(page.locator('#file-content-modal')).toBeVisible();
+    await switchToTxt(page);
+    await focusAtEnd(page);
+
+    const before = await readLiveRaw(page);
+    await page.keyboard.type('Z', { delay: 20 });
+    const after = await readLiveRaw(page);
+
+    // Z must land at the end, not offset by the count of \r\n before it.
+    expect(after).toBe(before + 'Z');
+
+    // DOM must agree with liveRaw.
+    const preText = await readEditorText(page);
+    expect(preText.replace(/\r\n/g, '\n').trimEnd()).toBe(after.trimEnd());
+  });
+
 });


### PR DESCRIPTION
liveRaw kept literal \r\n (2 chars per line break) while the rendered <pre> collapsed each \r\n to a single <br> (1 char). flatLength() in dom-index-map.js counts every <br> as 1, so nodeOffsetToIndex() under-counted by the number of \r\n sequences preceding the caret. Every beforeinput splice then landed N positions too far left, and the typed character visibly appeared offset from the cursor.

The same mismatch also prevented the dirty flag from ever clearing on CRLF files: openNormalized was \n-only but liveRaw kept \r\n, so trimEnd() equality never held.

Normalising \r\n and lone \r to \n in activeRaw/liveRaw on load puts both representations on the same convention at the single site where they diverged. Every other consumer (apply-change splicing, innerText reads, the save path in decodeModalHtml) already treated \n as canonical, so no downstream changes are needed. Saves already emitted \n-only output, so normalising on load just removes an existing load/save asymmetry.

Regression test installs a CRLF fixture, types a character at the end, and asserts it lands at the true end of liveRaw rather than offset by the count of preceding \r\n sequences.