### PR TITLE
Preserve live editor DOM element to maintain native undo history

### DIFF
--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -40,6 +40,7 @@ export async function loadContentModal(fileToOpen) {
     session.liveHtml = session.activeHtml;
 
     setIsCurrentVersion(true);
+    document.getElementById('modal-content-text').innerHTML = '';
     fileContentRender();
 
     await saveBackupEntry(appState.openFileSnapshot, 'open');

--- a/public/js/ui/ui-functions-render/render-file-content.js
+++ b/public/js/ui/ui-functions-render/render-file-content.js
@@ -1,7 +1,7 @@
 import { appState } from '../../services/store.js';
 import { highlightPropMatches } from '../ui-functions-highlight/apply-highlights.js';
 import { applyDiffHighlights, clearDiffHighlights } from '../ui-functions-highlight/diff-highlight.js';
-import { getEditorElement, hasUnsavedChanges } from '../../editing/manage-unsaved-changes.js';
+import { hasUnsavedChanges } from '../../editing/manage-unsaved-changes.js';
 import { getIsCurrentVersion } from '../../editing/editable-state.js';
 
 /**
@@ -29,35 +29,64 @@ export function fileContentRender() {
     const renderToggle = document.getElementById('render_toggle');
     renderToggle.checked = appState.editState;
     const isTxtMode = appState.editState;
+    const isCurrent = getIsCurrentVersion();
 
-    if (isTxtMode) {
-        textbox.innerHTML = '';
-        const preElement = document.createElement('pre');
-        preElement.classList.add('pre-text-enlarge');
-        preElement.classList.add('text-editor');
-        // Only allow editing if we are on the current (live) version
-        preElement.contentEditable = getIsCurrentVersion() ? 'plaintext-only' : 'false';
-        preElement.innerHTML = appState.editSession.activeRaw
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/\r\n|\r|\n/g, '<br>');
-        if (getIsCurrentVersion()) {
+    // Keep the live editor element in the DOM across view switches so the browser's
+    // native undo history is preserved. Only hide/show it rather than destroy/rebuild.
+    const liveEditor = textbox.querySelector('.text-editor');
+
+    // Remove all non-live-editor children (elements and text nodes)
+    Array.from(textbox.childNodes)
+        .filter(node => node.nodeType !== 1 || !node.classList.contains('text-editor'))
+        .forEach(node => node.remove());
+
+    if (isTxtMode && isCurrent) {
+        if (liveEditor) {
+            liveEditor.style.display = '';
+        } else {
+            const preElement = document.createElement('pre');
+            preElement.classList.add('pre-text-enlarge');
+            preElement.classList.add('text-editor');
+            preElement.contentEditable = 'plaintext-only';
+            preElement.innerHTML = appState.editSession.activeRaw
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/\r\n|\r|\n/g, '<br>');
             preElement.dataset.action = 'file-content-edit';
+            textbox.appendChild(preElement);
         }
-        textbox.appendChild(preElement);
     } else {
-        textbox.innerHTML = appState.editSession.activeHtml;
+        if (liveEditor) liveEditor.style.display = 'none';
+
+        if (isTxtMode) {
+            // Historical txt view — read-only pre, no .text-editor class
+            const preElement = document.createElement('pre');
+            preElement.classList.add('pre-text-enlarge');
+            preElement.contentEditable = 'false';
+            preElement.innerHTML = appState.editSession.activeRaw
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/\r\n|\r|\n/g, '<br>');
+            textbox.appendChild(preElement);
+        } else {
+            // HTML view — move rendered nodes in without wiping the hidden live editor
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = appState.editSession.activeHtml;
+            while (tempDiv.firstChild) {
+                textbox.appendChild(tempDiv.firstChild);
+            }
+        }
     }
 
     // apply search highlights if any
     highlightPropMatches();
 
     // apply diff highlights if a prior version
-    if (getIsCurrentVersion()) {
+    if (isCurrent) {
         clearDiffHighlights();
     } else {
-        // Compare the historical "active" content against the "live" current version
         applyDiffHighlights(appState.editSession.activeRaw, appState.editSession.liveRaw);
     }
 

--- a/tests/18-editor-dom-persistence.spec.js
+++ b/tests/18-editor-dom-persistence.spec.js
@@ -1,0 +1,161 @@
+const { test, expect } = require('@playwright/test');
+const { setupMockDirectoryWithHistory } = require('./helpers');
+
+async function waitForHistoryOptions(page, count) {
+  await page.waitForFunction((n) => {
+    const sel = document.getElementById('file-content-history-select');
+    return sel && sel.options.length >= n;
+  }, count);
+}
+
+async function openModal(page) {
+  await page.click('[data-click-loadfolder]');
+  await page.locator('.note-grid').first().click();
+  await expect(page.locator('#file-content-modal')).toBeVisible();
+  await waitForHistoryOptions(page, 1);
+}
+
+async function switchToTxt(page) {
+  await page.evaluate(() => {
+    const t = document.getElementById('render_toggle');
+    if (!t.checked) t.click();
+  });
+  await expect(page.locator('#modal-content-text .text-editor')).toBeVisible();
+}
+
+async function switchToHtml(page) {
+  await page.evaluate(() => {
+    const t = document.getElementById('render_toggle');
+    if (t.checked) t.click();
+  });
+}
+
+test.describe('editor DOM persistence and no accumulation', () => {
+
+  test('live editor is preserved (hidden) when switching to html view', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+
+    expect(await page.locator('#modal-content-text .text-editor').count()).toBe(1);
+
+    await switchToHtml(page);
+
+    // .text-editor still in DOM but hidden via display:none
+    expect(await page.locator('#modal-content-text .text-editor').count()).toBe(1);
+    const isHidden = await page.evaluate(() => {
+      const el = document.querySelector('#modal-content-text .text-editor');
+      return el && window.getComputedStyle(el).display === 'none';
+    });
+    expect(isHidden).toBe(true);
+
+    // HTML content is visible
+    await expect(page.locator('#modal-content-text')).toContainText('Current content today');
+  });
+
+  test('live editor reappears and only one copy exists after toggling back to txt', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await switchToHtml(page);
+    await switchToTxt(page);
+
+    expect(await page.locator('#modal-content-text .text-editor').count()).toBe(1);
+    const isVisible = await page.evaluate(() => {
+      const el = document.querySelector('#modal-content-text .text-editor');
+      return el && window.getComputedStyle(el).display !== 'none';
+    });
+    expect(isVisible).toBe(true);
+  });
+
+  test('html content nodes are removed when switching back to txt', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+    await switchToHtml(page);
+    await switchToTxt(page);
+
+    // Only .text-editor should remain as a direct child
+    const nonEditorDirectChildren = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('#modal-content-text > *'))
+        .filter(el => !el.classList.contains('text-editor')).length
+    );
+    expect(nonEditorDirectChildren).toBe(0);
+  });
+
+  test('live editor is preserved (hidden) when browsing a historical snapshot', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await waitForHistoryOptions(page, 3);
+    await switchToTxt(page);
+
+    await page.selectOption('#file-content-history-select', { index: 2 });
+
+    expect(await page.locator('#modal-content-text .text-editor').count()).toBe(1);
+    const isHidden = await page.evaluate(() => {
+      const el = document.querySelector('#modal-content-text .text-editor');
+      return el && window.getComputedStyle(el).display === 'none';
+    });
+    expect(isHidden).toBe(true);
+
+    // A separate read-only pre (no .text-editor) holds the historical content
+    const historicalPreCount = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('#modal-content-text pre'))
+        .filter(p => !p.classList.contains('text-editor')).length
+    );
+    expect(historicalPreCount).toBe(1);
+  });
+
+  test('historical pre is removed and live editor reappears on return to current', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await waitForHistoryOptions(page, 3);
+    await switchToTxt(page);
+
+    await page.selectOption('#file-content-history-select', { index: 2 });
+    await page.selectOption('#file-content-history-select', { value: 'current' });
+
+    expect(await page.locator('#modal-content-text .text-editor').count()).toBe(1);
+    const isVisible = await page.evaluate(() => {
+      const el = document.querySelector('#modal-content-text .text-editor');
+      return el && window.getComputedStyle(el).display !== 'none';
+    });
+    expect(isVisible).toBe(true);
+
+    const historicalPreCount = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('#modal-content-text pre'))
+        .filter(p => !p.classList.contains('text-editor')).length
+    );
+    expect(historicalPreCount).toBe(0);
+  });
+
+  test('multiple view round trips never accumulate .text-editor copies or stale children', async ({ page }) => {
+    await setupMockDirectoryWithHistory(page);
+    await page.goto('/');
+    await openModal(page);
+    await waitForHistoryOptions(page, 3);
+    await switchToTxt(page);
+
+    // 3 round trips across different view combinations
+    await switchToHtml(page);
+    await switchToTxt(page);
+    await page.selectOption('#file-content-history-select', { index: 2 });
+    await page.selectOption('#file-content-history-select', { value: 'current' });
+    await switchToHtml(page);
+    await switchToTxt(page);
+
+    expect(await page.locator('#modal-content-text .text-editor').count()).toBe(1);
+
+    const nonEditorDirectChildren = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('#modal-content-text > *'))
+        .filter(el => !el.classList.contains('text-editor')).length
+    );
+    expect(nonEditorDirectChildren).toBe(0);
+  });
+
+});


### PR DESCRIPTION
Instead of destroying and rebuilding the contentEditable <pre> on every view switch, hide it with display:none so the browser's undo history survives toggling html/txt mode and browsing history snapshots.

On txt+current: show (or create) the live .text-editor element and remove other sibling content. On all other views: hide the live editor and render html or historical-snapshot content alongside it in the DOM.

The container is cleared on each new file load so undo history from a prior file is intentionally discarded.

https://claude.ai/code/session_014fdyWJwpNzk64UYczEoHoa