### PR TITLE
Add F5 shortcut to insert today's date in text editor

### DIFF
--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -19,6 +19,7 @@ import { handleDeleteFilter } from './ui-functions-click/filter-delete.js';
 import { handleFilterToggleActive } from './ui-functions-click/filter-toggle-active.js';
 import { handleHistorySelectChange } from './ui-functions-click/history-select-change.js';
 import { handleSaveFileCopy } from './ui-functions-click/save-file-copy.js';
+import { handleInsertDateShortcut } from './ui-functions-click/insert-date-shortcut.js';
 import { handlePageChange } from './pagination/handle-page-change.js';
 import { handleOpenSettings, handleCloseSettings, handleCloseSettingsOutside } from './ui-functions-click/settings-modal.js';
 
@@ -123,6 +124,10 @@ function keyDownDelegate(evt) {
             evt.preventDefault();
             handleSaveFileCopy();
         }
+    }
+    if (evt.key === 'F5' && evt.target.dataset.action === 'file-content-edit') {
+        evt.preventDefault();
+        handleInsertDateShortcut();
     }
 }
 

--- a/public/js/ui/ui-functions-click/insert-date-shortcut.js
+++ b/public/js/ui/ui-functions-click/insert-date-shortcut.js
@@ -1,0 +1,12 @@
+/**
+ * Inserts today's date (yyyy-mm-dd) at the cursor position in the text editor.
+ * Called when F5 is pressed while the editor element is focused.
+ * @returns {void}
+ */
+export function handleInsertDateShortcut() {
+    const today = new Date();
+    const dateString = today.getFullYear()
+        + '-' + String(today.getMonth() + 1).padStart(2, '0')
+        + '-' + String(today.getDate()).padStart(2, '0');
+    document.execCommand('insertText', false, dateString);
+}


### PR DESCRIPTION
Pressing F5 while the editor is focused inserts the current date (yyyy-mm-dd) at the cursor. Default browser behaviour (page refresh) is suppressed only when the editor element has focus.

https://claude.ai/code/session_0111Fzpy399MSF9vB28CnVgc