### PR TITLE
test: switch to txt mode before checking undo/redo button visibility

### DIFF
--- a/tests/19-undo-redo-buttons.spec.js
+++ b/tests/19-undo-redo-buttons.spec.js
@@ -29,6 +29,7 @@ test.describe('undo/redo footer buttons', () => {
     await setupMockDirectoryWithHistory(page);
     await page.goto('/');
     await openModal(page);
+    await switchToTxt(page);
 
     await expect(page.locator('[data-action="editor-undo"]')).toBeVisible();
     await expect(page.locator('[data-action="editor-redo"]')).toBeVisible();


### PR DESCRIPTION
Undo/redo buttons are now only shown in txt mode, so the visibility test must first activate the render toggle before asserting.

https://claude.ai/code/session_01313Rm9hVnjc4DEjDgo5sCP