### PR TITLE
fix: don't close file content modal on drag-select outside

### DIFF
--- a/public/js/ui/ui-functions-click/open-file-content-view-trans.js
+++ b/public/js/ui/ui-functions-click/open-file-content-view-trans.js
@@ -21,6 +21,13 @@ dialog.addEventListener('cancel', (evt) => {
     handleCloseModal();
 });
 
+// Track where the press started so a drag-select that ends on the backdrop
+// doesn't trigger the click-outside close handler below.
+let pressedOnDialog = false;
+dialog.addEventListener('pointerdown', (evt) => {
+    pressedOnDialog = evt.target === dialog;
+});
+
 window.addEventListener('beforeunload', (evt) => {
     if (hasUnsavedChanges()) evt.preventDefault();
 });
@@ -65,7 +72,9 @@ export function handleOpenFileContent(event, target) {
  */
 export function handeCloseModalOutside(event, target) {
 
-  if (event.target === dialog) {
+  // Require the press *and* release on the dialog itself; otherwise a text
+  // selection that crosses the modal edge would count as a click-outside.
+  if (event.target === dialog && pressedOnDialog) {
     handleCloseModal();
   }
 }


### PR DESCRIPTION
A click event's target is the common ancestor of mousedown/mouseup, so dragging a text selection from the modal content onto the backdrop was dispatching a click on the <dialog> and triggering the close handler. Track the pointerdown target and require both press and release on the dialog itself before closing.

https://claude.ai/code/session_01TpQ17q9HwrAgmWCtQ52cMV