### PR TITLE
Fix editor flash on modal re-open

### DIFF
--- a/public/js/ui/ui-functions-click/open-file-content-view-trans.js
+++ b/public/js/ui/ui-functions-click/open-file-content-view-trans.js
@@ -38,7 +38,7 @@ export function handleOpenFileContent(event, target) {
   file_box.classList.add("moving-file-content-view"); // animate *from* this element
 
   // 3. Animate the move (State 1 -> State 2)
-  document.startViewTransition(function () {
+  document.startViewTransition(async function () {
 
     dialog.showModal();
     dialog.classList.add("dialog-view"); // backdrop fade in
@@ -49,7 +49,7 @@ export function handleOpenFileContent(event, target) {
     document.getElementById('file-content-header').dataset.color = target.dataset.color;
     scrollingContent.dataset.color=target.dataset.color;
     resetAutosave();
-    loadContentModal(file_to_open);
+    await loadContentModal(file_to_open);
     scrollingContent.scrollTop = 0; // reset scroll position to top of page, rather than wherever you were on previous note on close.
   });
 }
@@ -101,6 +101,7 @@ function doClose() {
 
   transition.finished.then(async () => {
     dialog.close();
+    document.getElementById('modal-content-text').innerHTML = '';
 
     file_box.classList.remove("moving-file-content-view"); // make sure everything removed ready for next time
     movingbox.classList.remove("moving-file-content-view"); // make sure everything removed ready for next time


### PR DESCRIPTION
Clear #modal-content-text after the close transition finishes so stale .text-editor content is never in the DOM when the next open begins. Also await loadContentModal inside the startViewTransition callback so the browser captures the 'new' snapshot only after the incoming file is fully rendered, giving a smooth transition directly to the loaded state.

https://claude.ai/code/session_01GtGfEg9bAS7YnpmJMQx9qP