### PR TITLE
test: fix clickBackdrop helper to include pointerdown event

### DIFF
--- a/tests/11-unsaved-changes-alert.spec.js
+++ b/tests/11-unsaved-changes-alert.spec.js
@@ -33,8 +33,9 @@ async function editContent(page) {
 
 async function clickBackdrop(page) {
   await page.evaluate(() => {
-    document.getElementById('file-content-modal')
-      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const modal = document.getElementById('file-content-modal');
+    modal.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 }
 


### PR DESCRIPTION
Commit 298a35b added a pressedOnDialog guard so drag-selects don't close the modal. The test helper only dispatched a click; it now also dispatches the required pointerdown first.

https://claude.ai/code/session_01FyKkeGSgfZuSsy6bgXVBu5