### PR TITLE
harden rename flow against silent data-loss paths

### DIFF
--- a/public/js/editing/rename-backups.js
+++ b/public/js/editing/rename-backups.js
@@ -1,55 +1,76 @@
 import { appState } from '../services/store.js';
 import { BACKUP_FILENAME, SAVE_FOLDER } from '../constants.js';
-import { buildSaveFilename } from '../services/file-save.js';
+import { buildSaveFilename, writeAndVerifyHandle } from '../services/file-save.js';
 
 /**
  * Rewrites `.gypsum/history.gypsum` entries for the renamed file so past
- * snapshots continue to surface under the new name/path. No-op if the backup
- * file or folder does not exist yet.
+ * snapshots continue to surface under the new name/path. Returns a list of
+ * warning strings (empty on clean success or when there was nothing to do).
+ * Missing history file/folder is benign; corrupt JSON or a failed write
+ * produces a warning rather than a throw so the rename itself still completes.
  *
  * @param {object} params
  * @param {string} params.oldFilename
  * @param {string} params.oldFilepath
  * @param {string} params.newFilename
  * @param {string} params.newFilepath
- * @returns {Promise<void>}
+ * @returns {Promise<string[]>}
  */
 async function rewriteHistoryFile({ oldFilename, oldFilepath, newFilename, newFilepath }) {
+    let fileHandle;
+    let text;
     try {
         const gypsumDir = await appState.dirHandle.getDirectoryHandle(SAVE_FOLDER);
-        const fileHandle = await gypsumDir.getFileHandle(BACKUP_FILENAME);
-        const text = await (await fileHandle.getFile()).text();
-        if (!text.trim()) return;
-
-        const parsed = JSON.parse(text);
-        let changed = false;
-
-        const retag = entry => {
-            if (entry.filename === oldFilename && entry.filepath === oldFilepath) {
-                entry.filename = newFilename;
-                entry.filepath = newFilepath;
-                changed = true;
-            }
-        };
-
-        if (Array.isArray(parsed)) {
-            parsed.forEach(retag);
-            if (changed) {
-                const writable = await fileHandle.createWritable();
-                await writable.write(JSON.stringify(parsed, null, 2));
-                await writable.close();
-            }
-        } else if (parsed && Array.isArray(parsed.snapshots)) {
-            parsed.snapshots.forEach(retag);
-            if (changed) {
-                const writable = await fileHandle.createWritable();
-                await writable.write(JSON.stringify(parsed, null, 2));
-                await writable.close();
-            }
-        }
-    } catch {
-        // No backup file, inaccessible folder, or corrupt JSON — nothing to migrate.
+        fileHandle = await gypsumDir.getFileHandle(BACKUP_FILENAME);
+        text = await (await fileHandle.getFile()).text();
+    } catch (err) {
+        if (err?.name === 'NotFoundError') return [];
+        console.error('History migration: could not read history.gypsum', { oldFilename, newFilename, err });
+        return ['Could not read history file; past snapshots may still reference the old name.'];
     }
+
+    if (!text.trim()) return [];
+
+    let parsed;
+    try {
+        parsed = JSON.parse(text);
+    } catch (err) {
+        console.error('History migration: history.gypsum is corrupt', { oldFilename, newFilename, err });
+        return ['History file is corrupt; past snapshots may still reference the old name.'];
+    }
+
+    let changed = false;
+    const retag = entry => {
+        if (entry.filename === oldFilename && entry.filepath === oldFilepath) {
+            entry.filename = newFilename;
+            entry.filepath = newFilepath;
+            changed = true;
+        }
+    };
+
+    let toWrite;
+    if (Array.isArray(parsed)) {
+        parsed.forEach(retag);
+        if (changed) toWrite = JSON.stringify(parsed, null, 2);
+    } else if (parsed && Array.isArray(parsed.snapshots)) {
+        parsed.snapshots.forEach(retag);
+        if (changed) toWrite = JSON.stringify(parsed, null, 2);
+    }
+
+    if (toWrite === undefined) return [];
+
+    try {
+        const ok = await writeAndVerifyHandle(fileHandle, toWrite);
+        if (!ok) {
+            console.error('History migration: write verification failed', { oldFilename, newFilename });
+            return ['History file write could not be verified; past snapshots may be stale.'];
+        }
+    } catch (err) {
+        console.error('History migration: write threw', { oldFilename, newFilename, err });
+        return ['History file could not be updated; past snapshots may still reference the old name.'];
+    }
+
+    return [];
 }
 
 /**
@@ -76,18 +97,23 @@ async function moveTransientIfExists(gypsumDir, oldSaveName, newSaveName) {
  *   - <filename>-save.gypsum / <filename>-temp.gypsum: renamed to the new pattern.
  *
  * Safe to call even when there is no backup folder or no matching entries.
+ * Returns an array of warning strings (empty on clean success) so the caller
+ * can surface them to the user without aborting the rename itself.
  *
  * @param {object} params
  * @param {string} params.oldFilename
  * @param {string} params.oldFilepath
  * @param {string} params.newFilename
  * @param {string} params.newFilepath
- * @returns {Promise<void>}
+ * @returns {Promise<string[]>}
  */
 export async function migrateBackupsForRename({ oldFilename, oldFilepath, newFilename, newFilepath }) {
-    if (!appState.dirHandle) return;
+    if (!appState.dirHandle) return [];
 
-    await rewriteHistoryFile({ oldFilename, oldFilepath, newFilename, newFilepath });
+    const warnings = [];
+
+    const historyWarnings = await rewriteHistoryFile({ oldFilename, oldFilepath, newFilename, newFilepath });
+    warnings.push(...historyWarnings);
 
     try {
         const gypsumDir = await appState.dirHandle.getDirectoryHandle(SAVE_FOLDER);
@@ -97,7 +123,12 @@ export async function migrateBackupsForRename({ oldFilename, oldFilepath, newFil
         const newTemp = newSave.replace(/-save\.gypsum$/, '-temp.gypsum');
         await moveTransientIfExists(gypsumDir, oldSave, newSave);
         await moveTransientIfExists(gypsumDir, oldTemp, newTemp);
-    } catch {
-        // .gypsum folder not present — nothing to migrate.
+    } catch (err) {
+        if (err?.name !== 'NotFoundError') {
+            console.error('Transient migration: could not access .gypsum folder', { oldFilename, newFilename, err });
+            warnings.push('Could not access the .gypsum folder; any pending save/temp files were not migrated.');
+        }
     }
+
+    return warnings;
 }

--- a/public/js/editing/rename-file.js
+++ b/public/js/editing/rename-file.js
@@ -25,21 +25,26 @@ async function resolveTargetDir(folderPath) {
 
 /**
  * Checks whether an entry with `name` already exists in `dir`. If it does and
- * it is not the same entry as `selfHandle`, throws.
+ * it is not the same entry as `selfHandle`, surfaces a blocking alert (because
+ * the file appeared behind the app's back — validation already rejects clashes
+ * with loaded files) and cancels the rename. No "proceed anyway" option: a
+ * user never knowingly wants to overwrite a file they didn't know existed.
  * @param {FileSystemDirectoryHandle} dir
  * @param {string} name
  * @param {FileSystemFileHandle} selfHandle
+ * @param {string} folderPath - Normalised folder path, used only for the alert message.
  */
-async function assertNoCollision(dir, name, selfHandle) {
+async function assertNoCollision(dir, name, selfHandle, folderPath) {
     try {
         const existing = await dir.getFileHandle(name, { create: false });
         const same = await existing.isSameEntry(selfHandle);
         if (!same) {
-            throw new Error('A file with that name already exists here.');
+            const location = folderPath ? `"${folderPath}"` : 'this folder';
+            alert(`A file named "${name}" has just appeared in ${location}. Rename cancelled to prevent overwriting it.`);
+            throw new Error('Rename cancelled: unknown file at target.');
         }
     } catch (err) {
         if (err?.name === 'NotFoundError') return;
-        if (err instanceof Error && err.message.startsWith('A file')) throw err;
         throw err;
     }
 }
@@ -61,8 +66,9 @@ export async function renameFile({ file, newFolder, newName }) {
     const newFilepath = newFolder ? `${newFolder}/${newName}` : newName;
 
     const targetDir = await resolveTargetDir(newFolder);
-    await assertNoCollision(targetDir, newName, file.handle);
+    await assertNoCollision(targetDir, newName, file.handle, newFolder);
 
+    // .move() overwrites any entry at the target silently — assertNoCollision is the only guard.
     await file.handle.move(targetDir, newName);
 
     file.filename = newName;

--- a/public/js/editing/rename-validate.js
+++ b/public/js/editing/rename-validate.js
@@ -7,7 +7,9 @@ const FORBIDDEN_IN_FILENAME = /[\/\\\x00-\x1f]/;
 
 /**
  * Normalises a folder path: trims, strips leading/trailing slashes, splits on '/',
- * drops empty segments. Returns the cleaned path or null if any segment is '.' or '..'.
+ * drops empty segments. Returns the cleaned path or null if any segment is '.',
+ * '..', or starts with '.' (hidden folders, which `directory-handler.js` skips
+ * on load — renaming into one would silently lose the file).
  * @param {string} raw
  * @returns {string|null}
  */
@@ -17,6 +19,7 @@ function normaliseFolder(raw) {
     const segments = trimmed.split('/').filter(s => s !== '');
     for (const seg of segments) {
         if (seg === '.' || seg === '..') return null;
+        if (seg.startsWith('.')) return null;
     }
     return segments.join('/');
 }
@@ -34,6 +37,9 @@ function normaliseFolder(raw) {
 export function validateRenameInputs({ currentFile, newFolder, newName, myFiles }) {
     const name = (newName ?? '').trim();
     if (name === '') return { ok: false, reason: 'Filename cannot be empty.' };
+    if (name.startsWith('.')) {
+        return { ok: false, reason: 'Filename cannot start with a dot.' };
+    }
     if (FORBIDDEN_IN_FILENAME.test(name)) {
         return { ok: false, reason: 'Filename cannot contain slashes or control characters.' };
     }
@@ -44,7 +50,7 @@ export function validateRenameInputs({ currentFile, newFolder, newName, myFiles 
 
     const folder = normaliseFolder(newFolder);
     if (folder === null) {
-        return { ok: false, reason: "Folder path cannot contain '.' or '..' segments." };
+        return { ok: false, reason: 'Folder names cannot start with a dot or be "." / ".."' };
     }
 
     const newFilepath = folder ? `${folder}/${name}` : name;

--- a/public/js/ui/ui-functions-click/rename-file-click.js
+++ b/public/js/ui/ui-functions-click/rename-file-click.js
@@ -144,7 +144,7 @@ export async function handleRenameConfirm(evt) {
             newFolder: result.normalizedFolder,
             newName: result.normalizedName,
         });
-        await migrateBackupsForRename(outcome);
+        const warnings = await migrateBackupsForRename(outcome);
 
         setOpenedFilename(outcome.newFilename);
 
@@ -154,6 +154,10 @@ export async function handleRenameConfirm(evt) {
         }
 
         renderFiles(true, true);
+
+        if (warnings.length) {
+            alert(`File renamed, but:\n\n- ${warnings.join('\n- ')}`);
+        }
 
         if (dialog) dialog.close();
     } catch (err) {


### PR DESCRIPTION
Addresses four classes of accidental data loss in the rename flow:

1. Reject dot-prefixed folder segments in validation so users can't rename a file into .gypsum/ or any other hidden folder that the loader skips — the file would otherwise vanish from the list on reload.

2. On an unknown-file collision at the target (a file that appeared after validation checked myFiles), raise a blocking alert and cancel the rename rather than relying on the inline error slot. FileSystemFileHandle.move() overwrites silently; the pre-check is the only guard.

3. Narrow the bare catch {} blocks in rename-backups.js so missing- file errors stay benign but corruption or write failures are logged and surfaced as warnings. Use the existing writeAndVerifyHandle helper to catch partial writes of history.gypsum. migrateBackupsForRename now returns a warning list that the dialog displays after a successful rename.

4. Reject dot-prefixed filenames in validation for consistency with the folder rule (also catches pathological .md / ..md names).

https://claude.ai/code/session_01C81zMAA5JR7EqZ5amUCF7j