### PR TITLE
Use full filepath as file id to fix same-basename clash

### DIFF
--- a/public/js/editing/backup-history-read.js
+++ b/public/js/editing/backup-history-read.js
@@ -2,7 +2,7 @@ import { appState } from '../services/store.js';
 import { BACKUP_FILENAME, SAVE_FOLDER } from '../constants.js';
 
 /**
- * Reads history.gypsum and returns all entries matching the given filename, newest-first.
+ * Reads history.gypsum and returns all entries matching the given (filename, filepath), newest-first.
  * Handles both the current line-pool format ({ lines, snapshots }) and the legacy flat-array
  * format transparently. Returns [] if no directory handle, backup file absent, or unreadable.
  *
@@ -10,11 +10,16 @@ import { BACKUP_FILENAME, SAVE_FOLDER } from '../constants.js';
  * Reading before the new entry is written means history shows only past states,
  * not a duplicate of the content the user is currently viewing.
  *
+ * Both filename and filepath are required: files with the same basename in
+ * different folders must not share history. Legacy entries that predate the
+ * filepath field will not match and are intentionally not migrated.
+ *
  * @async
  * @param {string} filename
+ * @param {string} filepath
  * @returns {Promise<Array<{filepath: string, filename: string, content: string, lineRefs: number[]|undefined, lines: string[]|undefined, timestamp: string, event: string}>>}
  */
-export async function readBackupHistory(filename) {
+export async function readBackupHistory(filename, filepath) {
     if (!appState.dirHandle) return [];
     try {
         const gypsumDir = await appState.dirHandle.getDirectoryHandle(SAVE_FOLDER);
@@ -25,12 +30,12 @@ export async function readBackupHistory(filename) {
 
         if (Array.isArray(parsed)) {
             // Legacy format: entries already carry a plain `content` string
-            return parsed.filter(e => e.filename === filename).reverse();
+            return parsed.filter(e => e.filename === filename && e.filepath === filepath).reverse();
         }
 
         const { lines, snapshots } = parsed;
         return snapshots
-            .filter(s => s.filename === filename)
+            .filter(s => s.filename === filename && s.filepath === filepath)
             .reverse()
             .map(s => ({
                 filepath: s.filepath,

--- a/public/js/editing/refresh-file-state.js
+++ b/public/js/editing/refresh-file-state.js
@@ -20,9 +20,8 @@ export async function refreshFileAfterSave(snapshot) {
         if (fileIndex === -1) return;
 
         const existingFile = appState.myFiles[fileIndex];
-        const loadOrder = parseInt(existingFile.id.slice(1), 10);
 
-        const freshFile = await getFileDataAndMetadata(existingFile.handle, loadOrder);
+        const freshFile = await getFileDataAndMetadata(existingFile.handle, 0);
 
         const tagsHaveChanged = !tagsEqual(existingFile.tags, freshFile.tags);
         const colorHasChanged = existingFile.color !== freshFile.color;

--- a/public/js/editing/rename-file.js
+++ b/public/js/editing/rename-file.js
@@ -73,17 +73,18 @@ export async function renameFile({ file, newFolder, newName }) {
 
     file.filename = newName;
     file.filepath = newFilepath;
+    file.id = newFilepath;
 
     if (appState.myFileHandlesMap) {
-        appState.myFileHandlesMap.delete(oldFilename);
-        appState.myFileHandlesMap.set(newName, file.handle);
+        appState.myFileHandlesMap.delete(oldFilepath);
+        appState.myFileHandlesMap.set(newFilepath, file.handle);
     }
 
-    if (appState.openFileSnapshot?.filename === oldFilename) {
+    if (appState.openFileSnapshot?.filepath === oldFilepath) {
         appState.openFileSnapshot.filename = newName;
         appState.openFileSnapshot.filepath = newFilepath;
     }
-    if (appState.closeSnapshot?.filename === oldFilename) {
+    if (appState.closeSnapshot?.filepath === oldFilepath) {
         appState.closeSnapshot.filename = newName;
         appState.closeSnapshot.filepath = newFilepath;
     }

--- a/public/js/services/directory-handler.js
+++ b/public/js/services/directory-handler.js
@@ -46,13 +46,13 @@ export async function loadDirectoryFileHandles() {
     const fileEntries = await getFilesRecursive(dirHandle);
 
     const filePromises = fileEntries.map(({ handle, filepath }, index) =>
-        getFileDataAndMetadata(handle, index).then(fileObj => ({ ...fileObj, filepath }))
+        getFileDataAndMetadata(handle, index).then(fileObj => ({ ...fileObj, filepath, id: filepath }))
     );
 
     const filesWithMetadata = await Promise.all(filePromises);
 
     const fileHandleMap = filesWithMetadata.reduce((map, fileObject) => {
-        map.set(fileObject.filename, fileObject.handle);
+        map.set(fileObject.id, fileObject.handle);
         return map;
     }, new Map());
 

--- a/public/js/services/file-handler.js
+++ b/public/js/services/file-handler.js
@@ -36,16 +36,22 @@ export async function loadFileHandles() {
 
     const startTime = performance.now();
 
-    // Map file handles to promises from the function above
-    const filePromises = fileHandles.map((handle, index) => getFileDataAndMetadata(handle, index));
+    // Map file handles to promises from the function above.
+    // Single-file picker has no folder context, so filepath collapses to filename.
+    const filePromises = fileHandles.map((handle, index) =>
+        getFileDataAndMetadata(handle, index).then(fileObj => ({
+            ...fileObj,
+            filepath: fileObj.filename,
+            id: fileObj.filename,
+        }))
+    );
 
     // Await all promises to resolve concurrently (quicker than loading one by one)
     const filesWithMetadata = await Promise.all(filePromises);
 
     const fileHandleMap = filesWithMetadata.reduce((map, fileObject) => {
-        // fileObject.filename is the key
-        // fileObject.handle is the value
-        map.set(fileObject.filename, fileObject.handle); 
+        // fileObject.id (= filepath) is the key, fileObject.handle is the value
+        map.set(fileObject.id, fileObject.handle);
         return map;
     }, new Map());
 

--- a/public/js/services/file-parsing/file-info.js
+++ b/public/js/services/file-parsing/file-info.js
@@ -43,7 +43,6 @@ export async function getFileDataAndMetadata(handle, loadOrder) {
         tags: tagData.tagMap,
         color: tagData.colorFirst,
         lastModified: new Date(file.lastModified),
-        id: "a" + loadOrder.toString(),
         ...(yamlData)
     };
 

--- a/public/js/services/store.js
+++ b/public/js/services/store.js
@@ -77,7 +77,7 @@ export const propertySortMap = new Map();
  */
 export const FILE_PROPERTIES = new Map([
   ['sizeInBytes', {label: 'size', type: 'number', column_width: 120, display_order: 6 }],
-  ['id', { type: 'number', column_width: 40, display_order: 1 }],
+  ['id', { type: 'string', column_width: 40, display_order: 1 }],
   ['title', { type: 'string', column_width: 350, display_order: 2 }],
   ['filename', { type: 'string', column_width: 250, display_order: 1 }],
   ['lastModified', {label: 'last modified', type: 'date', column_width: 150, display_order: 4 }],

--- a/public/js/ui/pagination/check-file-on-page.js
+++ b/public/js/ui/pagination/check-file-on-page.js
@@ -4,7 +4,7 @@ import { appState } from '../../services/store.js';
  * Returns true if the file is on the current page.
  * pageFileIds is pre-computed from visibleFiles, which already applies the active
  * AND/OR filter mode, so no second filter check is needed here.
- * @param {number} fileId
+ * @param {string} fileId
  * @returns {boolean}
  */
 export function checkFileOnPage(fileId) {

--- a/public/js/ui/render-file-list-grid.js
+++ b/public/js/ui/render-file-list-grid.js
@@ -35,7 +35,7 @@ export function renderFileList_grid(renderEverything) {
   //      const tag_list = file.tags.join(" ");
         const filename_html = renderFilename(file.filename);
         file_html += `
-        <div class="note-grid color-dynamic" data-color="${file.color}" data-filename="${file.filename}" data-action="open-file-content-modal">
+        <div class="note-grid color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal">
 
             <div data-prop="filename">${filename_html}</div>
 

--- a/public/js/ui/render-file-list-list.js
+++ b/public/js/ui/render-file-list-list.js
@@ -36,7 +36,7 @@ export function renderFileList_list(renderEverything) {
                     <details>
                         <summary data-prop="filename">${filename_html} ${tag_pills_html}</summary>
                         <ul>
-                        <li><span class="show-content-tag color-dynamic" data-color="${file.color}" data-filename="${file.filename}" data-action="open-file-content-modal">open</span></li>
+                        <li><span class="show-content-tag color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal">open</span></li>
                         `;
             for (const key in file) {
                 const value = file[key];

--- a/public/js/ui/render-file-list-search.js
+++ b/public/js/ui/render-file-list-search.js
@@ -26,7 +26,7 @@ export function renderFileList_search(renderEverything) {
             }
 
             file_html += `
-                <div class="search-view-item color-dynamic" data-color="${file.color}" data-filename="${file.filename}" data-action="open-file-content-modal">
+                <div class="search-view-item color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal">
 
                     <div class="search-view-fileinfo">
                         <div class="note-search" data-color="${file.color}">

--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -8,10 +8,10 @@ import { fileContentRender } from '../ui-functions-render/render-file-content.js
 /**
  * Loads the content of a file, wraps front matter, parses tags and markdown, and then triggers the render.
  * @async
- * @param {string} fileToOpen - The name of the file to load content for.
+ * @param {string} fileId - The unique id (full path from root) of the file to load content for.
  */
-export async function loadContentModal(fileToOpen) {
-    const fileHandle = appState.myFileHandlesMap.get(fileToOpen);
+export async function loadContentModal(fileId) {
+    const fileHandle = appState.myFileHandlesMap.get(fileId);
     const fileChosen = await fileHandle.getFile();
 
     const raw = await fileChosen.text();
@@ -29,10 +29,10 @@ export async function loadContentModal(fileToOpen) {
     session.openTextLen = session.openNormalized.replace(/\n/g, '').length; // \n → <br> in DOM, invisible to textContent
     session.isDirty = false;
 
-    const fileObj = appState.myFiles.find(f => f.filename === fileToOpen);
+    const fileObj = appState.myFiles.find(f => f.id === fileId);
     appState.openFileSnapshot = {
-        filepath: fileObj?.filepath ?? fileToOpen,
-        filename: fileToOpen,
+        filepath: fileObj?.filepath ?? fileId,
+        filename: fileObj?.filename ?? fileId,
         content: raw,
     };
 
@@ -43,10 +43,10 @@ export async function loadContentModal(fileToOpen) {
     document.getElementById('modal-content-text').innerHTML = '';
     fileContentRender();
 
-    const filepathandname = appState.myFiles.find(f => f.filename === fileToOpen)?.filepath ?? fileToOpen;
+    const filepathandname = fileObj?.filepath ?? fileId;
     document.getElementById('rename-file-btn').innerHTML = filepathandname;
 
     await saveBackupEntry(appState.openFileSnapshot, 'open');
-    loadHistorySelect(fileToOpen);
-    console.log(fileToOpen);
+    loadHistorySelect(fileObj?.filename ?? fileId, fileObj?.filepath ?? fileId);
+    console.log(fileId);
 }

--- a/public/js/ui/ui-functions-click/open-file-content-view-trans.js
+++ b/public/js/ui/ui-functions-click/open-file-content-view-trans.js
@@ -14,16 +14,16 @@ const movingbox = document.getElementById("moving-file-content-container"); // m
 const scrollingContent = document.getElementById("modal-content");
 const warningDialog = document.getElementById('modal-unsaved-warning');
 
-let openedFilename; // look up the live DOM element by filename on close, since a save can re-render and replace the original node
+let openedFileId; // look up the live DOM element by file id on close, since a save can re-render and replace the original node
 
 /**
- * Updates the tracked "opened filename" used by the close animation to find
+ * Updates the tracked "opened file id" used by the close animation to find
  * the originating card. Call after a rename so the close animation targets
  * the renamed card rather than the (now-gone) old one.
- * @param {string} newFilename
+ * @param {string} newFileId
  */
-export function setOpenedFilename(newFilename) {
-    openedFilename = newFilename;
+export function setOpenedFileId(newFileId) {
+    openedFileId = newFileId;
 }
 
 dialog.addEventListener('cancel', (evt) => {
@@ -50,8 +50,8 @@ window.addEventListener('beforeunload', (evt) => {
  */
 export function handleOpenFileContent(event, target) {
 
-  const file_to_open = target.dataset.filename;
-  openedFilename = file_to_open;
+  const file_to_open = target.dataset.fileId;
+  openedFileId = file_to_open;
   target.classList.add("moving-file-content-view"); // animate *from* this element
 
   // 3. Animate the move (State 1 -> State 2)
@@ -62,7 +62,8 @@ export function handleOpenFileContent(event, target) {
     movingbox.classList.add("moving-file-content-view");  // animate *to* this file target element
     target.classList.remove("moving-file-content-view");
 
-    initHistorySelect(file_to_open);
+    const fileObj = appState.myFiles.find(f => f.id === file_to_open);
+    initHistorySelect(fileObj?.filepath ?? file_to_open);
     document.getElementById('file-content-header').dataset.color = target.dataset.color;
     scrollingContent.dataset.color=target.dataset.color;
     resetAutosave();
@@ -112,8 +113,8 @@ function doClose() {
   // Re-query the target now: if the file list was re-rendered since open
   // (e.g. after save), the node captured on open is detached and would not
   // participate in the view transition.
-  const file_box = openedFilename
-    ? document.querySelector(`[data-action="open-file-content-modal"][data-filename="${CSS.escape(openedFilename)}"]`)
+  const file_box = openedFileId
+    ? document.querySelector(`[data-action="open-file-content-modal"][data-file-id="${CSS.escape(openedFileId)}"]`)
     : null;
 
   const transition = document.startViewTransition(function () {

--- a/public/js/ui/ui-functions-click/rename-file-click.js
+++ b/public/js/ui/ui-functions-click/rename-file-click.js
@@ -5,7 +5,7 @@ import { renameFile } from '../../editing/rename-file.js';
 import { migrateBackupsForRename } from '../../editing/rename-backups.js';
 import { renderFiles } from '../ui-functions-render/a-render-all-files.js';
 import { renderHistorySelect } from '../ui-functions-render/render-history-select.js';
-import { setOpenedFilename } from './open-file-content-view-trans.js';
+import { setOpenedFileId } from './open-file-content-view-trans.js';
 
 const dialogId = 'modal-rename-file';
 const folderInputId = 'rename-folder-input';
@@ -23,9 +23,9 @@ function getErrorSlot() { return document.getElementById(errorSlotId); }
  * @returns {object|null}
  */
 function getCurrentFile() {
-    const filename = appState.openFileSnapshot?.filename;
-    if (!filename) return null;
-    return appState.myFiles.find(f => f.filename === filename) ?? null;
+    const filepath = appState.openFileSnapshot?.filepath;
+    if (!filepath) return null;
+    return appState.myFiles.find(f => f.id === filepath) ?? null;
 }
 
 /**
@@ -146,14 +146,14 @@ export async function handleRenameConfirm(evt) {
         });
         const warnings = await migrateBackupsForRename(outcome);
 
-        setOpenedFilename(outcome.newFilename);
+        setOpenedFileId(outcome.newFilepath);
 
         const renameBtn = document.getElementById('rename-file-btn');
         if (renameBtn) renameBtn.innerHTML = outcome.newFilepath;
 
         const historySelect = document.getElementById('file-content-history-select');
         if (historySelect) {
-            historySelect.innerHTML = renderHistorySelect(outcome.newFilename, appState.historyEntries ?? []);
+            historySelect.innerHTML = renderHistorySelect(outcome.newFilepath, appState.historyEntries ?? []);
         }
 
         renderFiles(true, true);

--- a/public/js/ui/ui-functions-click/setup-history-select.js
+++ b/public/js/ui/ui-functions-click/setup-history-select.js
@@ -6,12 +6,12 @@ import { updateUnsavedIndicator } from '../ui-functions-render/render-file-conte
 /**
  * Resets the history select to show only "current" for a newly opened file.
  * History is loaded asynchronously by loadHistorySelect once the file content is ready.
- * @param {string} filename
+ * @param {string} filepath
  * @returns {void}
  */
-export function initHistorySelect(filename) {
+export function initHistorySelect(filepath) {
     document.getElementById('file-content-history-select').innerHTML =
-        renderHistorySelect(filename, []);
+        renderHistorySelect(filepath, []);
 }
 
 /**
@@ -20,13 +20,14 @@ export function initHistorySelect(filename) {
  * the user can compare their in-session edits against.
  * Intentionally fire-and-forget — the select updates when the read completes.
  * @param {string} filename
+ * @param {string} filepath
  * @returns {void}
  */
-export function loadHistorySelect(filename) {
-    readBackupHistory(filename).then(entries => {
+export function loadHistorySelect(filename, filepath) {
+    readBackupHistory(filename, filepath).then(entries => {
         appState.historyEntries = entries;
         document.getElementById('file-content-history-select').innerHTML =
-            renderHistorySelect(filename, entries);
+            renderHistorySelect(filepath, entries);
         updateUnsavedIndicator();
     });
 }

--- a/public/js/ui/ui-functions-render/render-filename.js
+++ b/public/js/ui/ui-functions-render/render-filename.js
@@ -16,15 +16,16 @@ return `<span class="copyhighlight">
 
 /**
  * Renders a filename with a copy-to-clipboard button and an "open" button.
- * @param {string} filename - The filename to render.
+ * @param {string} filename - The filename to render (display + clipboard payload).
  * @param {string} color - The color associated with the file.
+ * @param {string} fileId - The file's unique id (full path from root); used to identify the click target.
  * @returns {string} The HTML string for the rendered filename and buttons.
  */
-export function renderFilenamePlusOpenBtn(filename, color) {
+export function renderFilenamePlusOpenBtn(filename, color, fileId) {
 
-return `<span class="show-content-tag color-dynamic" data-color="${color}" data-filename="${filename}" data-action="open-file-content-modal">open</span><span class="copyhighlight"><i><span class="copyflag" 
+return `<span class="show-content-tag color-dynamic" data-color="${color}" data-file-id="${fileId}" data-action="open-file-content-modal">open</span><span class="copyhighlight"><i><span class="copyflag"
             data-action="copy-filename"
-            title="copy filename to clipboard" 
+            title="copy filename to clipboard"
             data-filename="${filename}">©</span>&nbsp;${filename}
     </i>
   </span>`;

--- a/public/js/ui/ui-functions-render/render-history-select.js
+++ b/public/js/ui/ui-functions-render/render-history-select.js
@@ -1,5 +1,3 @@
-import { appState } from '../../services/store.js';
-
 /**
  * Renders the inner HTML for the history select element.
  *
@@ -12,12 +10,11 @@ import { appState } from '../../services/store.js';
  * The "current" option has no version label. Historical options are labelled
  * v-1 (most recent backup), v-2, v-3, … newest-first.
  *
- * @param {string} filename - The name of the open file.
+ * @param {string} filepath - The full path of the open file (displayed in the button).
  * @param {Array<{timestamp: string}>} entries - Backup entries, newest-first.
  * @returns {string} HTML string for the select's innerHTML.
  */
-export function renderHistorySelect(filename, entries) {
-    const filepath = appState.myFiles.find(f => f.filename === filename)?.filepath ?? filename;
+export function renderHistorySelect(filepath, entries) {
     const historyOptions = entries.map((entry, i) =>
         `<option value="${i}">` +
           `<span class="opt-time">${formatTimestamp(entry.timestamp)}</span>` +

--- a/public/js/ui/ui-functions-table/render-table-rows.js
+++ b/public/js/ui/ui-functions-table/render-table-rows.js
@@ -25,7 +25,7 @@ export function renderTableRows(current_props, renderEverything) {
                 switch (prop.type) {
                     case 'string':
                         if (prop.name === 'filename') {
-                            cellContent = renderFilenamePlusOpenBtn(value || '', file.color); // so that it shows the "copy filename" thing
+                            cellContent = renderFilenamePlusOpenBtn(value || '', file.color, file.id); // so that it shows the "copy filename" thing
                         } else {
                             cellContent = value || '';
                         }

--- a/tests/07-backup.spec.js
+++ b/tests/07-backup.spec.js
@@ -98,14 +98,14 @@ test.describe('local file backup', () => {
     await expect(page.locator('.note-grid')).toHaveCount(2);
 
     // Open first file
-    await page.locator('[data-action="open-file-content-modal"][data-filename="alpha.md"]').click();
+    await page.locator('[data-action="open-file-content-modal"][data-file-id="alpha.md"]').click();
     await expect(page.locator('#file-content-modal')).toBeVisible();
     await waitForBackupEntries(page, 1);
 
     // Close, then open second file — different filename+content → must append
     await page.click('[data-action="close-file-content-modal"]');
     await expect(page.locator('#file-content-modal')).not.toBeVisible();
-    await page.locator('[data-action="open-file-content-modal"][data-filename="beta.md"]').click();
+    await page.locator('[data-action="open-file-content-modal"][data-file-id="beta.md"]').click();
     await expect(page.locator('#file-content-modal')).toBeVisible();
     await waitForBackupEntries(page, 2);
 
@@ -154,14 +154,14 @@ test.describe('local file backup', () => {
     await expect(page.locator('.note-grid')).toHaveCount(2);
 
     // Open alpha, close alpha → 1 entry (close deduplicates against the open)
-    await page.locator('[data-action="open-file-content-modal"][data-filename="alpha.md"]').click();
+    await page.locator('[data-action="open-file-content-modal"][data-file-id="alpha.md"]').click();
     await expect(page.locator('#file-content-modal')).toBeVisible();
     await waitForBackupEntries(page, 1);
     await page.click('[data-action="close-file-content-modal"]');
     await expect(page.locator('#file-content-modal')).not.toBeVisible();
 
     // Open beta → 2 entries total
-    await page.locator('[data-action="open-file-content-modal"][data-filename="beta.md"]').click();
+    await page.locator('[data-action="open-file-content-modal"][data-file-id="beta.md"]').click();
     await expect(page.locator('#file-content-modal')).toBeVisible();
     await waitForBackupEntries(page, 2);
     await page.click('[data-action="close-file-content-modal"]');
@@ -170,7 +170,7 @@ test.describe('local file backup', () => {
     // Re-open alpha with identical content — must deduplicate against alpha's earlier entry,
     // not beta's (the globally last entry). No write should occur; entry count must stay at 2.
     const snapshotBefore = await page.evaluate(() => window.__backupFileContent);
-    await page.locator('[data-action="open-file-content-modal"][data-filename="alpha.md"]').click();
+    await page.locator('[data-action="open-file-content-modal"][data-file-id="alpha.md"]').click();
     await expect(page.locator('#file-content-modal')).toBeVisible();
     // Wait for modal to be fully loaded (history select populated) then confirm no extra write.
     await page.waitForFunction(() => {

--- a/tests/08-history-select.spec.js
+++ b/tests/08-history-select.spec.js
@@ -272,7 +272,7 @@ test.describe('history select in file content modal', () => {
     await expect(page.locator('.note-grid')).toHaveCount(2);
 
     // Open other.md — it has no prior history; the on-open snapshot becomes v-1
-    await page.locator('[data-action="open-file-content-modal"][data-filename="other.md"]').click();
+    await page.locator('[data-action="open-file-content-modal"][data-file-id="other.md"]').click();
     await expect(page.locator('#file-content-modal')).toBeVisible();
 
     await waitForHistoryOptions(page, 2);


### PR DESCRIPTION
Two files with the same basename in different folders (e.g. notes.md and archive/notes.md) previously collided on the click-to-open path: the filename-keyed myFileHandlesMap overwrote one handle with the other, and clicking either card opened the wrong file. History reads also mixed snapshots from both files because the filter keyed on filename alone.

- file.id is now the full filepath from root; filename stays as the basename for display only.
- myFileHandlesMap keyed by id; HTML click targets carry data-file-id; the copy-to-clipboard button keeps data-filename as its payload.
- Click, rename, close-animation, and snapshot paths all look up by id.
- backup-history-read now filters by (filename, filepath); snapshot writes already included both fields, so new history.gypsum entries work correctly. Legacy entries without filepath are not migrated.

https://claude.ai/code/session_01P1txNvKb9ordyWikY77MAa