### PR TITLE
Handle case-only renames as no-op and reject them in validation

### DIFF
--- a/public/js/editing/rename-file.js
+++ b/public/js/editing/rename-file.js
@@ -111,6 +111,11 @@ export async function renameFile({ file, newFolder, newName }) {
     const newFilepath = newFolder ? `${newFolder}/${newName}` : newName;
     const oldFolder = extractDirFromFilepath(oldFilepath);
 
+    // Deterministic no-op for case-only path changes across platforms.
+    if (newFilepath.toLowerCase() === oldFilepath.toLowerCase()) {
+        return { oldFilename, oldFilepath, newFilename: oldFilename, newFilepath: oldFilepath };
+    }
+
     const targetDir = await resolveTargetDir(newFolder);
     await assertNoCollision(targetDir, newName, file.handle, newFolder);
 

--- a/public/js/editing/rename-validate.js
+++ b/public/js/editing/rename-validate.js
@@ -32,7 +32,7 @@ function normaliseFolder(raw) {
  * @param {string} params.newFolder - User-entered target folder path (may be empty for root).
  * @param {string} params.newName - User-entered new filename.
  * @param {Array<{filename: string, filepath: string}>} params.myFiles
- * @returns {{ok: true, normalizedFolder: string, normalizedName: string, unchanged: boolean} | {ok: false, reason: string}}
+ * @returns {{ok: true, normalizedFolder: string, normalizedName: string} | {ok: false, reason: string}}
  */
 export function validateRenameInputs({ currentFile, newFolder, newName, myFiles }) {
     const name = (newName ?? '').trim();
@@ -54,16 +54,15 @@ export function validateRenameInputs({ currentFile, newFolder, newName, myFiles 
     }
 
     const newFilepath = folder ? `${folder}/${name}` : name;
-    const unchanged = newFilepath === currentFile.filepath;
-
-    if (!unchanged) {
-        const collision = myFiles.some(f =>
-            f !== currentFile && f.filepath.toLowerCase() === newFilepath.toLowerCase()
-        );
-        if (collision) {
-            return { ok: false, reason: 'A loaded file with that path already exists.' };
-        }
+    if (newFilepath.toLowerCase() === currentFile.filepath.toLowerCase()) {
+        return { ok: false, reason: 'Rename cancelled: path is unchanged (case-only renames are not supported).' };
+    }
+    const collision = myFiles.some(f =>
+        f !== currentFile && f.filepath.toLowerCase() === newFilepath.toLowerCase()
+    );
+    if (collision) {
+        return { ok: false, reason: 'A loaded file with that path already exists.' };
     }
 
-    return { ok: true, normalizedFolder: folder, normalizedName: name, unchanged };
+    return { ok: true, normalizedFolder: folder, normalizedName: name };
 }

--- a/public/js/ui/ui-functions-click/rename-file-click.js
+++ b/public/js/ui/ui-functions-click/rename-file-click.js
@@ -133,11 +133,6 @@ export async function handleRenameConfirm(evt) {
 
     const dialog = getDialog();
 
-    if (result.unchanged) {
-        if (dialog) dialog.close();
-        return;
-    }
-
     try {
         const outcome = await renameFile({
             file,


### PR DESCRIPTION
### Motivation

- Prevent confusing or platform-dependent behavior when a user attempts a case-only rename (e.g. "file.txt" → "File.txt").
- Ensure the UI and rename logic behave deterministically across case-sensitive and case-insensitive filesystems.

### Description

- Added an early deterministic no-op in `renameFile` that returns immediately when the new path differs only by case by comparing `newFilepath.toLowerCase()` and `oldFilepath.toLowerCase()`.
- Updated `validateRenameInputs` to reject case-only renames and removed the `unchanged` return flag from its API, returning an explicit error reason for such attempts.
- Removed the UI early-exit for `unchanged` in `handleRenameConfirm` so the validation and rename codepaths handle the case uniformly, and updated JSDoc/return types accordingly.

### Testing

- Ran the automated unit test suite with `npm test`, and the tests passed.
- Ran the linter with `npm run lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87f048870832997c1127afe25a67e)