### PR TITLE
Fix diff highlighting for historical text view and update highlight import

### DIFF
--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -4,7 +4,7 @@ import { saveBackupEntry } from '../../editing/local-backup.js';
 import { loadHistorySelect } from './setup-history-select.js';
 import { setIsCurrentVersion } from '../../editing/editable-state.js';
 import { fileContentRender } from '../ui-functions-render/render-file-content.js';
-import { applyHighlights } from '../ui-functions-highlight/apply-highlights.js';
+import { highlightPropMatches } from '../ui-functions-highlight/apply-highlights.js';
 
 /**
  * Loads the content of a file, wraps front matter, parses tags and markdown, and then triggers the render.

--- a/public/js/ui/ui-functions-highlight/diff-highlight.js
+++ b/public/js/ui/ui-functions-highlight/diff-highlight.js
@@ -77,7 +77,8 @@ export function applyDiffHighlights(oldContent, currentContent) {
     if (isTxtMode) {
         // Content is rendered as text nodes separated by <br> elements.
         // Build a line-index → text-node map by walking the child nodes.
-        const preEl = container.querySelector('pre');
+        const preEl = container.querySelector('pre.historical-snapshot')
+            ?? container.querySelector('pre.text-editor');
         if (!preEl) return;
 
         const lineNodes = [];

--- a/public/js/ui/ui-functions-render/render-file-content.js
+++ b/public/js/ui/ui-functions-render/render-file-content.js
@@ -62,6 +62,7 @@ export function fileContentRender() {
             // Historical txt view — read-only pre, no .text-editor class
             const preElement = document.createElement('pre');
             preElement.classList.add('pre-text-enlarge');
+            preElement.classList.add('historical-snapshot');
             preElement.contentEditable = 'false';
             preElement.innerHTML = appState.editSession.activeRaw
                 .replace(/&/g, '&amp;')


### PR DESCRIPTION
### Motivation

- Make diff highlighting work when viewing historical (read-only) text snapshots in the modal by ensuring the pre element is identifiable. 
- Reflect a refactor/rename of the highlight utility import to the new `highlightPropMatches` symbol. 
- Ensure highlights are applied reliably whether the editable or historical pre is present.

### Description

- Replaced the `applyHighlights` import with the renamed `highlightPropMatches` from `apply-highlights.js`. 
- Add the `historical-snapshot` class to the read-only `pre` element used for historical text rendering. 
- Update the diff highlight selector to prefer `pre.historical-snapshot` and fall back to `pre.text-editor` when building line-node maps. 
- Preserve existing behavior of clearing and setting diff highlights when switching between current and historical views.

### Testing

- Ran the project test suite with `npm test` against these UI changes and all tests passed. 
- Ran the linter with `npm run lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2fbb17d0832982165ed44bce2e3d)