### PR TITLE
Await history-select load before applying content highlights

### DIFF
--- a/public/js/ui/ui-functions-click/load-file-content.js
+++ b/public/js/ui/ui-functions-click/load-file-content.js
@@ -45,10 +45,9 @@ export async function loadContentModal(fileId) {
     fileContentRender();
 
     await saveBackupEntry(appState.openFileSnapshot, 'open');
-    loadHistorySelect(fileObj?.filename ?? fileId, fileObj?.filepath ?? fileId);
+    await loadHistorySelect(fileObj?.filename ?? fileId, fileObj?.filepath ?? fileId);
+    applyHighlights();
 
     console.log(fileId);
 
-    // apply search highlights if any
-    highlightPropMatches();
 }

--- a/public/js/ui/ui-functions-click/setup-history-select.js
+++ b/public/js/ui/ui-functions-click/setup-history-select.js
@@ -18,16 +18,14 @@ export function initHistorySelect(filepath) {
  * Reads backup history for the file and repopulates the select with all entries.
  * The snapshot saved on open is intentionally shown — it serves as the baseline
  * the user can compare their in-session edits against.
- * Intentionally fire-and-forget — the select updates when the read completes.
  * @param {string} filename
  * @param {string} filepath
- * @returns {void}
+ * @returns {Promise<void>}
  */
-export function loadHistorySelect(filename, filepath) {
-    readBackupHistory(filename, filepath).then(entries => {
-        appState.historyEntries = entries;
-        document.getElementById('file-content-history-select').innerHTML =
-            renderHistorySelect(filepath, entries);
-        updateUnsavedIndicator();
-    });
+export async function loadHistorySelect(filename, filepath) {
+    const entries = await readBackupHistory(filename, filepath);
+    appState.historyEntries = entries;
+    document.getElementById('file-content-history-select').innerHTML =
+        renderHistorySelect(filepath, entries);
+    updateUnsavedIndicator();
 }


### PR DESCRIPTION
### Motivation
- Ensure highlights are applied only after the history select DOM is fully populated to avoid race conditions where highlights are computed against stale DOM.
- Make history loading part of the open flow so callers can await its completion before continuing UI work.

### Description
- Made `loadHistorySelect` in `public/js/ui/ui-functions-click/setup-history-select.js` `async` and changed it to `await readBackupHistory(...)`, then set `#file-content-history-select.innerHTML`, and call `updateUnsavedIndicator()`.
- Updated `loadContentModal` in `public/js/ui/ui-functions-click/load-file-content.js` to `await loadHistorySelect(fileObj?.filename ?? fileId, fileObj?.filepath ?? fileId)` and then call `applyHighlights()`.
- Removed the previous trailing direct highlight call so highlights now run only after the history select DOM replacement completes.

### Testing
- Ran `node --check public/js/ui/ui-functions-click/setup-history-select.js` which completed successfully.
- Ran `node --check public/js/ui/ui-functions-click/load-file-content.js` which completed successfully.
- Verified the modified files are `public/js/ui/ui-functions-click/setup-history-select.js` and `public/js/ui/ui-functions-click/load-file-content.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea30c7c0b883299997f99a36fd509c)