### PR TITLE
Use CSS position-try-fallbacks to keep autocomplete popup on-screen

### DIFF
--- a/public/css/tag-autocomplete.css
+++ b/public/css/tag-autocomplete.css
@@ -10,12 +10,34 @@
     anchor-name: --tag-ac-search;
 }
 
+@position-try --ac-flip-up {
+    top: auto;
+    bottom: anchor(top);
+    margin-top: 0;
+    margin-bottom: 4px;
+}
+
+@position-try --ac-flip-left {
+    left: auto;
+    right: anchor(right);
+}
+
+@position-try --ac-flip-up-left {
+    top: auto;
+    bottom: anchor(top);
+    left: auto;
+    right: anchor(right);
+    margin-top: 0;
+    margin-bottom: 4px;
+}
+
 .tag-autocomplete-popup {
     position: fixed;
     inset: auto;
     top: anchor(bottom);
     left: anchor(left);
     margin-top: 4px;
+    position-try-fallbacks: --ac-flip-up, --ac-flip-left, --ac-flip-up-left;
     z-index: 100;
     background-color: var(--colour-neutral);
     border: 1.5px solid var(--colour-contr);


### PR DESCRIPTION
When the caret is near the bottom or right edge, the popup now flips above or leftward automatically via three @position-try fallbacks. No JS required; relies on CSS Anchor Positioning (Chrome 125+, which is already required by the File System Access API this app depends on).

https://claude.ai/code/session_018KUb2s3Y2rRFLEpguANRai