### PR TITLE
Sort autocomplete tag results: prefix matches first, then mid-word ma…

### DIFF
--- a/public/js/autocomplete/tag-query-detect.js
+++ b/public/js/autocomplete/tag-query-detect.js
@@ -27,19 +27,20 @@ export function detectSearchboxTrigger(value, caretPos) {
 
 /**
  * Case-insensitive substring filter over tagArray, capped at maxResults.
- * @param {string[]} tagArray
+ * Results are sorted so prefix matches come before mid-word matches, both groups alphabetical.
+ * @param {string[]} tagArray - Must be pre-sorted alphabetically.
  * @param {string} query
  * @param {number} [maxResults=50]
  * @returns {string[]}
  */
 export function filterTags(tagArray, query, maxResults = 50) {
     const q = query.toLowerCase();
-    const out = [];
+    const starts = [], rest = [];
     for (const tag of tagArray) {
-        if (tag.toLowerCase().includes(q)) {
-            out.push(tag);
-            if (out.length >= maxResults) break;
-        }
+        const t = tag.toLowerCase();
+        if (t.startsWith(q)) starts.push(tag);
+        else if (t.includes(q)) rest.push(tag);
+        if (starts.length + rest.length >= maxResults) break;
     }
-    return out;
+    return [...starts, ...rest];
 }


### PR DESCRIPTION
…tches

https://claude.ai/code/session_01C4sRLkZJTqDp5bPsNYeTHn