### PR TITLE
Add ctrl+shift+s shortcut to open rename dialog from file content modal

### DIFF
--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -146,13 +146,21 @@ function changeDelegate(evt) {
  * Handles keydown events for global keyboard shortcuts.
  * Ctrl+S / Cmd+S triggers the file save action, suppressing the browser's
  * native save-page dialog (which also fires on keydown).
+ * Ctrl+Shift+S / Cmd+Shift+S opens the file rename/move dialog, but only
+ * when the file content modal is open.
  * @param {KeyboardEvent} evt
  */
 function keyDownDelegate(evt) {
     if (handleAutocompleteKeydown(evt)) return;
     handleKeyboardNavigate(evt);
     if (evt.ctrlKey || evt.metaKey) {
-        if (evt.key === 's') {
+        if (evt.shiftKey && evt.key === 'S') {
+            const modal = document.getElementById('file-content-modal');
+            if (modal?.open) {
+                evt.preventDefault();
+                handleFileOptionsOpen(evt);
+            }
+        } else if (evt.key === 's') {
             evt.preventDefault();
             handleSaveFileCopy();
         }

--- a/tests/23-rename-shortcut.spec.js
+++ b/tests/23-rename-shortcut.spec.js
@@ -1,0 +1,36 @@
+const { test, expect } = require('@playwright/test');
+const { setupMockDirectoryWithDeleteSupport } = require('./helpers');
+
+async function waitForHistoryOptions(page, count) {
+  await page.waitForFunction((n) => {
+    const sel = document.getElementById('file-content-history-select');
+    return sel && sel.options.length >= n;
+  }, count);
+}
+
+test.describe('ctrl+shift+s rename shortcut', () => {
+
+  test('opens the rename modal when the file content modal is open', async ({ page }) => {
+    await setupMockDirectoryWithDeleteSupport(page);
+    await page.goto('/');
+    await page.click('[data-click-loadfolder]');
+    await page.locator('.note-grid').first().click();
+    await expect(page.locator('#file-content-modal')).toBeVisible();
+    await waitForHistoryOptions(page, 1);
+
+    await page.keyboard.press('Control+Shift+S');
+
+    await expect(page.locator('#modal-file-options')).toBeVisible();
+  });
+
+  test('does nothing when the file content modal is closed', async ({ page }) => {
+    await setupMockDirectoryWithDeleteSupport(page);
+    await page.goto('/');
+    await page.click('[data-click-loadfolder]');
+
+    await page.keyboard.press('Control+Shift+S');
+
+    await expect(page.locator('#modal-file-options')).not.toBeVisible();
+  });
+
+});


### PR DESCRIPTION
When the file content modal is open, pressing ctrl+shift+s (or cmd+shift+s on Mac) now opens the file rename/move dialog — the same action triggered by the file options button. The shortcut is a no-op when the modal is closed.

https://claude.ai/code/session_01KU8WfoLGtWbqffKMEzv2dM