### PR TITLE
Add / shortcut to focus searchbox

### DIFF
--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -151,6 +151,7 @@ function changeDelegate(evt) {
  * when the file content modal is open.
  * Alt+N creates a new file, but only when no modal is open.
  * Alt+1 focuses the first open-file-content-modal element, but only when no modal is open and a directory is loaded.
+ * / focuses the searchbox, but only when no modal is open.
  * @param {KeyboardEvent} evt
  */
 function keyDownDelegate(evt) {
@@ -179,6 +180,13 @@ function keyDownDelegate(evt) {
         if (!document.querySelector('dialog[open]') && appState.dirHandle) {
             const firstFileLink = document.querySelector('[data-action="open-file-content-modal"]');
             if (firstFileLink) firstFileLink.focus();
+        }
+    }
+    if (evt.key === '/' && !document.querySelector('dialog[open]')) {
+        const searchbox = document.getElementById('searchbox');
+        if (searchbox && document.activeElement !== searchbox) {
+            evt.preventDefault();
+            searchbox.focus();
         }
     }
     if (evt.key === 'F5' && evt.target.dataset.action === 'file-content-edit') {


### PR DESCRIPTION
Pressing / focuses the searchbox when no dialog is open. Skips if the searchbox is already focused, so typing / into the search field works normally.

https://claude.ai/code/session_01BT5kT9uHZjhNgJtM4CWNbt