### PR TITLE
Deactivate content search when show-tag-taxonomy is triggered

### DIFF
--- a/public/js/ui/ui-functions-click/tag-taxonomy-toggle.js
+++ b/public/js/ui/ui-functions-click/tag-taxonomy-toggle.js
@@ -1,11 +1,19 @@
 import { renderTagTaxonomy } from '../render-tag-taxonmy.js';
 import { appState } from '../../services/store.js';
+import { handleContentSearchToggle } from './search-content-toggle.js';
 
 /**
  * Renders the tag taxonomy into the DOM on user request.
+ * If full content search is active, deactivates it first so the tag search
+ * operates on properties only.
  * @returns {void}
  */
 export function handleShowTagTaxonomy() {
+    if (appState.search.depth.searchMode === "fullContent") {
+        const checkbox = document.getElementById("contentsearch");
+        checkbox.checked = false;
+        handleContentSearchToggle(null, checkbox);
+    }
     renderTagTaxonomy();
     const searchbox = document.getElementById('searchbox');
     searchbox.value = '';


### PR DESCRIPTION
If full content search mode is active when the user opens the tag taxonomy, it is now automatically turned off so that the pre-filled "tags:" search runs against properties only, not file contents.

https://claude.ai/code/session_0188yuWJSX2jpCks1EyU5ojh