### PR TITLE
Restore focus to filter pill after toggle re-render

### DIFF
--- a/public/js/ui/ui-functions-click/filter-toggle-state.js
+++ b/public/js/ui/ui-functions-click/filter-toggle-state.js
@@ -29,4 +29,6 @@ const filterObj = appState.search.filters.get(filterId);
 
     processSeachResults();
 
+    document.querySelector(`[data-action="filter-togglestate"][data-filterid="${filterId}"]`)?.focus();
+
 }


### PR DESCRIPTION
After handleFilterToggleState triggers processSeachResults(), renderFilters() replaces the DOM and the clicked button loses focus. Re-query the new button by filterId and focus it so keyboard navigation is preserved.

https://claude.ai/code/session_01293pRcoDwNkADFQ6Co2rpR