### PR TITLE
Add colour picker bottom-sheet dialog for inserting #color/ tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,6 +223,10 @@
     </form>
   </dialog>
 
+  <dialog id="modal-color-picker" data-action="close-color-picker-outside">
+    <div id="color-picker-content"></div>
+  </dialog>
+
   <datalist id="gypsum-folders"></datalist>
 
   <button id="btn-new-note" data-action="create-new-note" disabled>+</button>

--- a/public/css/modal-color-picker.css
+++ b/public/css/modal-color-picker.css
@@ -1,0 +1,59 @@
+#modal-color-picker {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: auto;
+    margin: 0;
+    width: 100%;
+    max-width: none;
+    border: none;
+    border-top: 1px solid var(--colour-contr);
+    border-radius: 12px 12px 0 0;
+    background-color: var(--colour-neutral-alt);
+    color: var(--colour-contr);
+    padding: 0;
+}
+
+#modal-color-picker::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+}
+
+#color-picker-content {
+    display: flex;
+    flex-direction: row;
+    overflow-x: auto;
+    padding: 0.75rem 1rem;
+}
+
+.color-circles-row {
+    display: flex;
+    flex-direction: row;
+    gap: 0.75rem;
+    flex-wrap: nowrap;
+}
+
+.color-circle {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: 2px solid var(--colour-contr);
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0;
+}
+
+.color-circle:focus {
+    outline: 3px solid var(--colour-compl);
+    outline-offset: 2px;
+}
+
+.color-circle[data-color-value="nocolor"] {
+    background: repeating-linear-gradient(
+        45deg,
+        transparent,
+        transparent 4px,
+        var(--colour-contr) 4px,
+        var(--colour-contr) 5px
+    );
+}

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -24,3 +24,13 @@ export const SAVE_FOLDER = '.gypsum';
 export const BACKUP_FILENAME = 'history.gypsum';
 
 export const PAGINATION_SIZE = 50;
+
+export const COLOR_NAMES = [
+    'nocolor', 'coral', 'steelblue', 'goldenrod', 'mediumseagreen',
+    'plum', 'tomato', 'cornflowerblue', 'sandybrown', 'mediumorchid', 'lightseagreen',
+];
+
+// Matches #color/name or #colour/name in plain text file content.
+// Lookbehind requires a space or newline before the tag.
+// Lookahead requires a space, newline, or end of string after.
+export const regex_color = /(?<= |\n)#(?:color|colour)\/(\w+)(?= |\n|$)/;

--- a/public/js/editing/color-pick-apply.js
+++ b/public/js/editing/color-pick-apply.js
@@ -1,0 +1,123 @@
+import { getEditorElement } from './manage-unsaved-changes.js';
+import { decodeModalHtml } from '../services/file-save.js';
+import { regex_color } from '../constants.js';
+
+/**
+ * Returns the cursor's character offset from the start of the editor's text content.
+ * @param {Element} editorEl
+ * @returns {number}
+ */
+export function saveCursorOffset(editorEl) {
+    const selection = window.getSelection();
+    if (!selection.rangeCount) return 0;
+    const range = selection.getRangeAt(0);
+    const preRange = document.createRange();
+    preRange.selectNodeContents(editorEl);
+    preRange.setEnd(range.startContainer, range.startOffset);
+    return preRange.toString().length;
+}
+
+/**
+ * Moves the cursor to a given character offset within the editor element.
+ * The pre element in plaintext-only mode is flat: only text nodes and <br> elements.
+ * @param {Element} editorEl
+ * @param {number} offset
+ */
+export function restoreCursorOffset(editorEl, offset) {
+    let remaining = offset;
+    for (const child of editorEl.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+            if (remaining <= child.nodeValue.length) {
+                const range = document.createRange();
+                range.setStart(child, remaining);
+                range.collapse(true);
+                window.getSelection().removeAllRanges();
+                window.getSelection().addRange(range);
+                return;
+            }
+            remaining -= child.nodeValue.length;
+        } else if (child.nodeName === 'BR') {
+            if (remaining === 0) {
+                const range = document.createRange();
+                range.setStartBefore(child);
+                range.collapse(true);
+                window.getSelection().removeAllRanges();
+                window.getSelection().addRange(range);
+                return;
+            }
+            remaining -= 1;
+        }
+    }
+    const range = document.createRange();
+    range.selectNodeContents(editorEl);
+    range.collapse(false);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+}
+
+/**
+ * Selects a text range [start, end) in the editor via a single childNodes walk.
+ * Each text node contributes its character length; each BR contributes 1 char,
+ * matching how decodeModalHtml counts newlines.
+ * @param {Element} editorEl
+ * @param {number} start
+ * @param {number} end
+ */
+function selectTextRange(editorEl, start, end) {
+    const range = document.createRange();
+    let pos = 0;
+    let startSet = false;
+    for (const child of editorEl.childNodes) {
+        const len = child.nodeType === Node.TEXT_NODE ? child.nodeValue.length : 1;
+        const childEnd = pos + len;
+        if (!startSet && childEnd > start) {
+            child.nodeType === Node.TEXT_NODE
+                ? range.setStart(child, start - pos)
+                : range.setStartBefore(child);
+            startSet = true;
+        }
+        if (startSet && childEnd >= end) {
+            child.nodeType === Node.TEXT_NODE
+                ? range.setEnd(child, end - pos)
+                : range.setEndAfter(child);
+            break;
+        }
+        pos = childEnd;
+    }
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+}
+
+/**
+ * Replaces the first #color/ tag in the editor with the chosen colour, or appends
+ * one on a new line at the end if none exists. Returns the adjusted cursor offset.
+ * Uses execCommand to preserve the browser's native undo stack.
+ * Reads content via decodeModalHtml (same as save path) to avoid innerText/<br> ambiguity.
+ * @param {string} colorName
+ * @param {number} savedOffset
+ * @returns {number}
+ */
+export function applyColorToEditor(colorName, savedOffset) {
+    const editorEl = getEditorElement();
+    if (!editorEl) return savedOffset;
+
+    const text = decodeModalHtml(editorEl.innerHTML);
+    const newTag = `#color/${colorName}`;
+    const match = regex_color.exec(text);
+
+    if (match) {
+        const oldTag = match[0];
+        selectTextRange(editorEl, match.index, match.index + oldTag.length);
+        document.execCommand('insertText', false, newTag);
+        const delta = newTag.length - oldTag.length;
+        return match.index < savedOffset ? savedOffset + delta : savedOffset;
+    }
+
+    const endRange = document.createRange();
+    endRange.selectNodeContents(editorEl);
+    endRange.collapse(false);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(endRange);
+    document.execCommand('insertText', false, `\n#color/${colorName}`);
+    return savedOffset;
+}

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -28,6 +28,7 @@ import { handleKeyboardNavigate } from './ui-functions-click/keyboard-navigate.j
 import { handleOpenSettings, handleCloseSettings, handleCloseSettingsOutside } from './ui-functions-click/settings-modal.js';
 import { handleEditorUndo } from './ui-functions-click/editor-undo.js';
 import { handleEditorRedo } from './ui-functions-click/editor-redo.js';
+import { handleEditorColorPick, handleColorCirclePick, handleCloseColorPickerOutside } from './ui-functions-click/editor-color-pick.js';
 import { handleShowTagTaxonomy, handleHideTagTaxonomy } from './ui-functions-click/tag-taxonomy-toggle.js';
 import { handleFileOptionsOpen, handleRenameConfirm, handleFileOptionsCancel, handleMoveConfirm } from './ui-functions-click/file-options-click.js';
 import { handleCreateNewNote } from './ui-functions-click/create-new-note-click.js';
@@ -74,6 +75,9 @@ const clickActionHandlers = {
     'close-settings-outside': handleCloseSettingsOutside,
     'editor-undo': handleEditorUndo,
     'editor-redo': handleEditorRedo,
+    'editor-color-pick': handleEditorColorPick,
+    'color-circle-pick': handleColorCirclePick,
+    'close-color-picker-outside': handleCloseColorPickerOutside,
     'show-tag-taxonomy': handleShowTagTaxonomy,
     'hide-tag-taxonomy': handleHideTagTaxonomy,
     'file-options-open': handleFileOptionsOpen,

--- a/public/js/ui/ui-functions-click/editor-color-pick.js
+++ b/public/js/ui/ui-functions-click/editor-color-pick.js
@@ -1,0 +1,60 @@
+import { COLOR_NAMES } from '../../constants.js';
+import { getEditorElement } from '../../editing/manage-unsaved-changes.js';
+import { saveCursorOffset, restoreCursorOffset, applyColorToEditor } from '../../editing/color-pick-apply.js';
+import { handleSaveFileCopy } from './save-file-copy.js';
+
+let pendingSavedOffset = 0;
+
+function buildColorPickerContent() {
+    const container = document.getElementById('color-picker-content');
+    const row = document.createElement('div');
+    row.className = 'color-circles-row';
+    for (const name of COLOR_NAMES) {
+        const btn = document.createElement('button');
+        btn.className = 'color-circle';
+        btn.dataset.action = 'color-circle-pick';
+        btn.dataset.colorValue = name;
+        btn.title = name;
+        if (name !== 'nocolor') btn.style.backgroundColor = name;
+        row.appendChild(btn);
+    }
+    container.innerHTML = '';
+    container.appendChild(row);
+}
+
+/**
+ * Opens the colour picker dialog. Saves the cursor position first.
+ */
+export function handleEditorColorPick() {
+    const editorEl = getEditorElement();
+    if (!editorEl) return;
+    pendingSavedOffset = saveCursorOffset(editorEl);
+    buildColorPickerContent();
+    document.getElementById('modal-color-picker').showModal();
+}
+
+/**
+ * Applies the chosen colour, restores cursor, and saves the file.
+ * @param {Event} _evt
+ * @param {Element} actionEl
+ */
+export function handleColorCirclePick(_evt, actionEl) {
+    const colorName = actionEl.dataset.colorValue;
+    document.getElementById('modal-color-picker').close();
+    const newOffset = applyColorToEditor(colorName, pendingSavedOffset);
+    const editorEl = getEditorElement();
+    if (editorEl) {
+        editorEl.focus();
+        restoreCursorOffset(editorEl, newOffset);
+    }
+    handleSaveFileCopy();
+}
+
+/**
+ * Closes the picker when the backdrop (the dialog element itself) is clicked.
+ * @param {Event} evt
+ */
+export function handleCloseColorPickerOutside(evt) {
+    const dialog = document.getElementById('modal-color-picker');
+    if (evt.target === dialog) dialog.close();
+}

--- a/public/style.css
+++ b/public/style.css
@@ -40,3 +40,4 @@
 @import url("css/pagination.css");
 @import url("css/button-new-note.css");
 @import url("css/tag-autocomplete.css");
+@import url("css/modal-color-picker.css");

--- a/tests/24-color-picker.spec.js
+++ b/tests/24-color-picker.spec.js
@@ -1,0 +1,122 @@
+const { test, expect } = require('@playwright/test');
+const {
+  setupMockDirectoryWithSaveSupport,
+  setupMockDirectoryForColorExisting,
+  setupMockDirectoryForColorMultiple,
+} = require('./helpers');
+
+async function openModal(page) {
+  await page.click('[data-click-loadfolder]');
+  await page.locator('.note-grid').first().click();
+  await expect(page.locator('#file-content-modal')).toBeVisible();
+}
+
+async function switchToTxt(page) {
+  await page.evaluate(() => {
+    const t = document.getElementById('render_toggle');
+    if (!t.checked) t.click();
+  });
+  await expect(page.locator('#modal-content-text pre')).toBeVisible();
+}
+
+function getCursorOffset(page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('#modal-content-text .text-editor');
+    if (!el) return 0;
+    const sel = window.getSelection();
+    if (!sel.rangeCount) return 0;
+    const range = sel.getRangeAt(0);
+    const pre = document.createRange();
+    pre.selectNodeContents(el);
+    pre.setEnd(range.startContainer, range.startOffset);
+    return pre.toString().length;
+  });
+}
+
+test.describe('colour picker modal', () => {
+
+  test('clicking the color button opens the colour picker modal', async ({ page }) => {
+    await setupMockDirectoryWithSaveSupport(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+
+    await page.click('[data-action="editor-color-pick"]');
+
+    await expect(page.locator('#modal-color-picker')).toBeVisible();
+    await expect(page.locator('[data-action="color-circle-pick"]').first()).toBeVisible();
+  });
+
+  test('existing colour above cursor is replaced and cursor offset is adjusted', async ({ page }) => {
+    // File: '# My Notes\n#color/coral\nText below'
+    // #color/coral starts at text offset 11 (after '# My Notes\n')
+    // 'coral' = 5 chars, 'steelblue' = 9 chars, delta = +4
+    await setupMockDirectoryForColorExisting(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+
+    // Place cursor at end of file (after the colour tag, so it is "above" the cursor)
+    await page.locator('#modal-content-text pre').click();
+    await page.evaluate(() => {
+      const el = document.querySelector('#modal-content-text .text-editor');
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      range.collapse(false);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+    });
+
+    const savedOffset = await getCursorOffset(page);
+
+    await page.click('[data-action="editor-color-pick"]');
+    await expect(page.locator('#modal-color-picker')).toBeVisible();
+    await page.click('[data-action="color-circle-pick"][data-color-value="steelblue"]');
+    await expect(page.locator('#modal-color-picker')).not.toBeVisible();
+
+    const editorText = await page.locator('#modal-content-text pre').textContent();
+    expect(editorText).toContain('#color/steelblue');
+    expect(editorText).not.toContain('#color/coral');
+
+    const newOffset = await getCursorOffset(page);
+    const delta = 'steelblue'.length - 'coral'.length; // 4
+    expect(newOffset).toBe(savedOffset + delta);
+  });
+
+  test('when no colour exists, new colour is added on a new line at the end', async ({ page }) => {
+    // File: '# My Notes\nSome content here' — no #color/ tag
+    await setupMockDirectoryWithSaveSupport(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+
+    await page.click('[data-action="editor-color-pick"]');
+    await expect(page.locator('#modal-color-picker')).toBeVisible();
+    await page.click('[data-action="color-circle-pick"][data-color-value="coral"]');
+    await expect(page.locator('#modal-color-picker')).not.toBeVisible();
+
+    const editorText = await page.locator('#modal-content-text pre').textContent();
+    expect(editorText).toContain('# My Notes');
+    expect(editorText).toContain('Some content here');
+    expect(editorText).toMatch(/#color\/coral\s*$/);
+  });
+
+  test('when multiple colours exist, only the first is changed', async ({ page }) => {
+    // File: '# My Notes\n#color/coral\nSome text\n#color/blue'
+    await setupMockDirectoryForColorMultiple(page);
+    await page.goto('/');
+    await openModal(page);
+    await switchToTxt(page);
+
+    await page.click('[data-action="editor-color-pick"]');
+    await expect(page.locator('#modal-color-picker')).toBeVisible();
+    await page.click('[data-action="color-circle-pick"][data-color-value="goldenrod"]');
+    await expect(page.locator('#modal-color-picker')).not.toBeVisible();
+
+    const editorText = await page.locator('#modal-content-text pre').textContent();
+    expect(editorText).toContain('#color/goldenrod');
+    expect(editorText).not.toContain('#color/coral');
+    expect(editorText).toContain('#color/blue');
+  });
+
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -538,4 +538,114 @@ async function setupMockDirectoryWithDeleteSupport(page) {
   });
 }
 
-module.exports = { setupMockFiles, setupMockDirectory, setupMockFilesMultiParent, setupMockFilesTagCount, setupMockDirectoryWithWrite, setupMockDirectoryWithHistory, setupMockDirectoryWithHistoryLinePool, setupMockDirectoryWithSaveSupport, setupMockDirectoryWithHistoryAndSave, setupMockDirectoryWithDeleteSupport };
+/**
+ * Directory with a file containing an existing #color/coral tag, with full save support.
+ * File: notes.md with content '# My Notes\n#color/coral\nText below'
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function setupMockDirectoryForColorExisting(page) {
+  await page.addInitScript(() => {
+    window.__savedFiles = {};
+    window.__originalFiles = {};
+    window.__backupFileContent = '';
+    const fileContent = '# My Notes\n#color/coral\nText below';
+    const makeFile = (name, content) => ({
+      kind: 'file', name,
+      getFile: async () => ({
+        name, size: content.length, lastModified: Date.now(),
+        text: async () => window.__originalFiles[name] ?? content,
+      }),
+      createWritable: async () => ({
+        write: async (c) => { window.__originalFiles[name] = c; },
+        close: async () => {},
+      }),
+    });
+    const backupHandle = {
+      getFile: async () => ({ text: async () => window.__backupFileContent }),
+      createWritable: async () => ({
+        write: async (c) => { window.__backupFileContent = c; },
+        close: async () => {},
+      }),
+    };
+    const gypsumDirHandle = {
+      getFileHandle: async (name, _options) => {
+        if (name === 'history.gypsum') return backupHandle;
+        if (!(name in window.__savedFiles)) window.__savedFiles[name] = '';
+        return {
+          getFile: async () => ({ text: async () => window.__savedFiles[name] }),
+          createWritable: async () => ({
+            write: async (c) => { window.__savedFiles[name] = c; },
+            close: async () => {},
+          }),
+        };
+      },
+      removeEntry: async (name) => { delete window.__savedFiles[name]; },
+    };
+    window.showDirectoryPicker = async () => ({
+      kind: 'directory', name: 'root',
+      values: async function* () { yield makeFile('notes.md', fileContent); },
+      getDirectoryHandle: async (name, _options) => {
+        if (name === '.gypsum') return gypsumDirHandle;
+        throw new Error(`Unexpected: ${name}`);
+      },
+    });
+  });
+}
+
+/**
+ * Directory with a file containing two #color/ tags, with full save support.
+ * File: notes.md with content '# My Notes\n#color/coral\nSome text\n#color/blue'
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function setupMockDirectoryForColorMultiple(page) {
+  await page.addInitScript(() => {
+    window.__savedFiles = {};
+    window.__originalFiles = {};
+    window.__backupFileContent = '';
+    const fileContent = '# My Notes\n#color/coral\nSome text\n#color/blue';
+    const makeFile = (name, content) => ({
+      kind: 'file', name,
+      getFile: async () => ({
+        name, size: content.length, lastModified: Date.now(),
+        text: async () => window.__originalFiles[name] ?? content,
+      }),
+      createWritable: async () => ({
+        write: async (c) => { window.__originalFiles[name] = c; },
+        close: async () => {},
+      }),
+    });
+    const backupHandle = {
+      getFile: async () => ({ text: async () => window.__backupFileContent }),
+      createWritable: async () => ({
+        write: async (c) => { window.__backupFileContent = c; },
+        close: async () => {},
+      }),
+    };
+    const gypsumDirHandle = {
+      getFileHandle: async (name, _options) => {
+        if (name === 'history.gypsum') return backupHandle;
+        if (!(name in window.__savedFiles)) window.__savedFiles[name] = '';
+        return {
+          getFile: async () => ({ text: async () => window.__savedFiles[name] }),
+          createWritable: async () => ({
+            write: async (c) => { window.__savedFiles[name] = c; },
+            close: async () => {},
+          }),
+        };
+      },
+      removeEntry: async (name) => { delete window.__savedFiles[name]; },
+    };
+    window.showDirectoryPicker = async () => ({
+      kind: 'directory', name: 'root',
+      values: async function* () { yield makeFile('notes.md', fileContent); },
+      getDirectoryHandle: async (name, _options) => {
+        if (name === '.gypsum') return gypsumDirHandle;
+        throw new Error(`Unexpected: ${name}`);
+      },
+    });
+  });
+}
+
+module.exports = { setupMockFiles, setupMockDirectory, setupMockFilesMultiParent, setupMockFilesTagCount, setupMockDirectoryWithWrite, setupMockDirectoryWithHistory, setupMockDirectoryWithHistoryLinePool, setupMockDirectoryWithSaveSupport, setupMockDirectoryWithHistoryAndSave, setupMockDirectoryWithDeleteSupport, setupMockDirectoryForColorExisting, setupMockDirectoryForColorMultiple };


### PR DESCRIPTION
Opens a bottom-sheet dialog from the existing editor-color-pick button. Colour circles built dynamically from COLOR_NAMES in constants.js. Uses execCommand('insertText') for all DOM writes to preserve the undo stack. Reads editor content via decodeModalHtml(innerHTML) for consistency with the save path. Cursor position is saved before the dialog opens and restored (with offset adjustment) after the colour is applied.

https://claude.ai/code/session_01GY1F9mfuhcE4MNhDob7QXT