### PR TITLE
Fix cursor not restored to original position when colour picker opene…

### DIFF
--- a/public/js/ui/ui-functions-click/editor-color-pick.js
+++ b/public/js/ui/ui-functions-click/editor-color-pick.js
@@ -50,6 +50,7 @@ function buildColorPickerContent() {
 export function handleEditorColorPick() {
     const editorEl = getEditorElement();
     if (!editorEl) return;
+    if (document.activeElement === editorEl) captureEditorCursorOffset();
     pendingSavedOffset = storedCursorOffset !== null
         ? storedCursorOffset
         : decodeModalHtml(editorEl.innerHTML).length;


### PR DESCRIPTION
…d via Alt+C

The mousedown handler captured the editor cursor before focus moved away, but Alt+C bypassed that entirely, leaving storedCursorOffset null and falling back to end-of-file. Now handleEditorColorPick captures the offset itself when the editor still has focus (keyboard path), and skips capture when focus has already moved to the button (mouse path, already handled by mousedown).

https://claude.ai/code/session_01JjBMxX9HvcuJAf2jLxFwNW