### PR TITLE
Add tar.gz backup buttons to settings modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,14 @@
       <label class="switch"><input type="checkbox" disabled><span class="slider"></span></label>
     </div>
 
+    <div class="settings-row">
+      <span class="settings-label">Backup</span>
+      <div class="settings-backup-btns">
+        <button class="settings-action-btn" data-action="backup-content">Content only</button>
+        <button class="settings-action-btn" data-action="backup-full">Full backup</button>
+      </div>
+    </div>
+
     <div class="settings-shortcuts">
       <h3 class="settings-shortcuts-heading">Keyboard shortcuts</h3>
 

--- a/public/css/modal-settings.css
+++ b/public/css/modal-settings.css
@@ -36,6 +36,25 @@
     cursor: not-allowed;
 }
 
+.settings-backup-btns {
+    display: flex;
+    gap: 8px;
+}
+
+.settings-action-btn {
+    padding: 3px 10px;
+    border: 1px solid var(--colour-contr);
+    border-radius: 4px;
+    background-color: transparent;
+    color: var(--colour-contr);
+    cursor: pointer;
+    font: inherit;
+}
+
+.settings-action-btn:hover {
+    box-shadow: var(--hover-box-shadow);
+}
+
 .settings-shortcuts {
     display: grid;
     grid-template-columns: 1fr auto;

--- a/public/js/backup/create-backup.js
+++ b/public/js/backup/create-backup.js
@@ -1,0 +1,107 @@
+import { createTarGzipStream } from './nanotar.js';
+import { appState } from '../services/store.js';
+import { SAVE_FOLDER } from '../constants.js';
+
+/**
+ * Recursively collect .txt and .md files from a directory handle.
+ * Mirrors the traversal pattern in directory-handler.js: skips dot-directories.
+ * @param {FileSystemDirectoryHandle} dirHandle
+ * @param {string} path
+ * @returns {Promise<Array<{handle: FileSystemFileHandle, filepath: string}>>}
+ */
+async function collectContentFiles(dirHandle, path = '') {
+    const results = [];
+    for await (const entry of dirHandle.values()) {
+        if (entry.kind === 'file') {
+            if (entry.name.endsWith('.txt') || entry.name.endsWith('.md')) {
+                const filepath = path ? `${path}/${entry.name}` : entry.name;
+                results.push({ handle: entry, filepath });
+            }
+        } else if (entry.kind === 'directory' && !entry.name.startsWith('.')) {
+            const subPath = path ? `${path}/${entry.name}` : entry.name;
+            const subResults = await collectContentFiles(entry, subPath);
+            results.push(...subResults);
+        }
+    }
+    return results;
+}
+
+/**
+ * Collect all files from the .gypsum directory.
+ * Returns [] if the folder does not exist yet — the backup still proceeds without it.
+ * @param {FileSystemDirectoryHandle} dirHandle
+ * @returns {Promise<Array<{handle: FileSystemFileHandle, filepath: string}>>}
+ */
+async function collectGypsumFiles(dirHandle) {
+    let gypsumDir;
+    try {
+        gypsumDir = await dirHandle.getDirectoryHandle(SAVE_FOLDER, { create: false });
+    } catch {
+        return [];
+    }
+    const results = [];
+    for await (const entry of gypsumDir.values()) {
+        if (entry.kind === 'file') {
+            results.push({ handle: entry, filepath: `${SAVE_FOLDER}/${entry.name}` });
+        }
+    }
+    return results;
+}
+
+/**
+ * Convert file handle entries to the { name, data } format nanotar expects.
+ * @param {Array<{handle: FileSystemFileHandle, filepath: string}>} fileEntries
+ * @returns {Promise<Array<{name: string, data: Uint8Array}>>}
+ */
+async function toTarEntries(fileEntries) {
+    return Promise.all(
+        fileEntries.map(async ({ handle, filepath }) => ({
+            name: filepath,
+            data: new Uint8Array(await (await handle.getFile()).arrayBuffer()),
+        }))
+    );
+}
+
+/**
+ * @returns {string} compact local timestamp, e.g. "20260509-143022"
+ */
+function buildTimestamp() {
+    const now = new Date();
+    const pad = (n) => String(n).padStart(2, '0');
+    return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+}
+
+/**
+ * @param {Blob} blob
+ * @param {string} filename
+ */
+function triggerDownload(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/**
+ * Collect, compress, and download a .tar.gz of directory contents.
+ * When includeGypsum is true, also includes all files in the .gypsum folder.
+ * No-ops silently if no directory folder is loaded (dirHandle is null).
+ * @param {boolean} includeGypsum
+ * @returns {Promise<void>}
+ */
+export async function downloadBackup(includeGypsum) {
+    const { dirHandle } = appState;
+    if (!dirHandle) return;
+
+    const contentEntries = await collectContentFiles(dirHandle);
+    const gypsumEntries = includeGypsum ? await collectGypsumFiles(dirHandle) : [];
+    const tarEntries = await toTarEntries([...contentEntries, ...gypsumEntries]);
+
+    const stream = createTarGzipStream(tarEntries);
+    const blob = await new Response(stream).blob();
+
+    const label = includeGypsum ? 'full' : 'content';
+    triggerDownload(blob, `gypsum-${label}-${buildTimestamp()}.tar.gz`);
+}

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -31,6 +31,7 @@ import { handleEditorColorPick, handleColorCirclePick, handleCloseColorPickerOut
 import { handleShowTagTaxonomy, handleHideTagTaxonomy, handleRenderTagTaxonomy } from './ui-functions-click/tag-taxonomy-toggle.js';
 import { handleFileOptionsOpen, handleRenameConfirm, handleFileOptionsCancel, handleMoveConfirm } from './ui-functions-click/file-options-click.js';
 import { handleCreateNewNote } from './ui-functions-click/create-new-note-click.js';
+import { handleBackupContent, handleBackupFull } from './ui-functions-click/backup-click.js';
 import { handleSearchboxAutocomplete, handleAutocompleteKeydown, handleAutocompleteClickOutside, initTagAutocomplete } from '../autocomplete/tag-autocomplete.js';
 
 /**
@@ -88,6 +89,8 @@ const clickActionHandlers = {
     'file-options-cancel': handleFileOptionsCancel,
     'delete-file': handleDeleteFile,
     'create-new-note': handleCreateNewNote,
+    'backup-content': handleBackupContent,
+    'backup-full': handleBackupFull,
 };
 
 const changeActionHandlers = {

--- a/public/js/ui/ui-functions-click/backup-click.js
+++ b/public/js/ui/ui-functions-click/backup-click.js
@@ -1,0 +1,15 @@
+import { downloadBackup } from '../../backup/create-backup.js';
+
+/**
+ * @returns {Promise<void>}
+ */
+export async function handleBackupContent() {
+    await downloadBackup(false);
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+export async function handleBackupFull() {
+    await downloadBackup(true);
+}

--- a/tests/25-tar-backup.spec.js
+++ b/tests/25-tar-backup.spec.js
@@ -1,0 +1,263 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Intercepts URL.createObjectURL and the anchor click in the download trigger,
+ * capturing the blob and intended filename without causing real navigation.
+ * Must be called before page.goto().
+ *
+ * After a backup button is clicked, window.__capturedDownload will be:
+ *   { blob: Blob, filename: string }
+ */
+async function interceptDownload(page) {
+    await page.addInitScript(() => {
+        window.__capturedDownload = null;
+
+        const origCreateObjectURL = URL.createObjectURL.bind(URL);
+        URL.createObjectURL = (blob) => {
+            const url = origCreateObjectURL(blob);
+            window.__capturedDownload = { blob, filename: null };
+            return url;
+        };
+
+        const origCreateElement = document.createElement.bind(document);
+        document.createElement = (tag) => {
+            const el = origCreateElement(tag);
+            if (tag === 'a') {
+                el.click = function () {
+                    if (window.__capturedDownload) {
+                        window.__capturedDownload.filename = el.download;
+                    }
+                };
+            }
+            return el;
+        };
+    });
+}
+
+/**
+ * Mock directory with three content files (two at root, one in a subdir) and
+ * two .gypsum files. Supports both content-only and full backup.
+ *
+ * Root structure:
+ *   top-level.md
+ *   notes.txt
+ *   subdir/
+ *     nested.md
+ *   .gypsum/          (only reachable via getDirectoryHandle, not values())
+ *     history.gypsum
+ *     notes-save.gypsum
+ */
+async function setupMockDirectoryForBackup(page) {
+    await page.addInitScript(() => {
+        const makeFile = (name, content) => {
+            const bytes = new TextEncoder().encode(content);
+            return {
+                kind: 'file', name,
+                getFile: async () => ({
+                    name,
+                    size: bytes.length,
+                    lastModified: Date.now(),
+                    text: async () => content,
+                    arrayBuffer: async () => bytes.buffer,
+                }),
+            };
+        };
+
+        const subdir = {
+            kind: 'directory', name: 'subdir',
+            values: async function* () {
+                yield makeFile('nested.md', '# Nested\nNested content #work');
+            },
+        };
+
+        const gypsumDir = {
+            kind: 'directory', name: '.gypsum',
+            values: async function* () {
+                yield makeFile('history.gypsum', '{"lines":[],"snapshots":[]}');
+                yield makeFile('notes-save.gypsum', 'autosaved content');
+            },
+        };
+
+        window.showDirectoryPicker = async () => ({
+            kind: 'directory', name: 'root',
+            values: async function* () {
+                yield makeFile('top-level.md', '# Top Level\nSome content');
+                yield makeFile('notes.txt', 'Plain text notes');
+                yield subdir;
+            },
+            getDirectoryHandle: async (name) => {
+                if (name === '.gypsum') return gypsumDir;
+                throw new DOMException(`${name} not found`, 'NotFoundError');
+            },
+        });
+    });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('tar backup buttons', () => {
+
+    test('both backup buttons are visible in the settings modal', async ({ page }) => {
+        await page.goto('/');
+        await page.click('[data-action="open-settings-modal"]');
+        await expect(page.locator('[data-action="backup-content"]')).toBeVisible();
+        await expect(page.locator('[data-action="backup-full"]')).toBeVisible();
+    });
+
+    test('content backup triggers download with correct filename pattern', async ({ page }) => {
+        await interceptDownload(page);
+        await setupMockDirectoryForBackup(page);
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+        await expect(page.locator('.note-grid')).toHaveCount(3);
+
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-content"]');
+
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+        const filename = await page.evaluate(() => window.__capturedDownload.filename);
+
+        expect(filename).toMatch(/^gypsum-content-\d{8}-\d{6}\.tar\.gz$/);
+    });
+
+    test('full backup triggers download with correct filename pattern', async ({ page }) => {
+        await interceptDownload(page);
+        await setupMockDirectoryForBackup(page);
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-full"]');
+
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+        const filename = await page.evaluate(() => window.__capturedDownload.filename);
+
+        expect(filename).toMatch(/^gypsum-full-\d{8}-\d{6}\.tar\.gz$/);
+    });
+
+    test('content backup archive contains only txt and md files', async ({ page }) => {
+        await interceptDownload(page);
+        await setupMockDirectoryForBackup(page);
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-content"]');
+
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+
+        const entryNames = await page.evaluate(async () => {
+            const { parseTarGzip } = await import('/public/js/backup/nanotar.js');
+            const buf = await window.__capturedDownload.blob.arrayBuffer();
+            const entries = await parseTarGzip(new Uint8Array(buf));
+            return entries.map(e => e.name);
+        });
+
+        expect(entryNames).toContain('top-level.md');
+        expect(entryNames).toContain('notes.txt');
+        expect(entryNames).toContain('subdir/nested.md');
+        expect(entryNames.every(n => !n.startsWith('.gypsum'))).toBe(true);
+    });
+
+    test('full backup archive contains txt/md files and .gypsum files', async ({ page }) => {
+        await interceptDownload(page);
+        await setupMockDirectoryForBackup(page);
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-full"]');
+
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+
+        const entryNames = await page.evaluate(async () => {
+            const { parseTarGzip } = await import('/public/js/backup/nanotar.js');
+            const buf = await window.__capturedDownload.blob.arrayBuffer();
+            const entries = await parseTarGzip(new Uint8Array(buf));
+            return entries.map(e => e.name);
+        });
+
+        expect(entryNames).toContain('top-level.md');
+        expect(entryNames).toContain('notes.txt');
+        expect(entryNames).toContain('subdir/nested.md');
+        expect(entryNames).toContain('.gypsum/history.gypsum');
+        expect(entryNames).toContain('.gypsum/notes-save.gypsum');
+    });
+
+    test('full backup proceeds even when .gypsum folder does not exist', async ({ page }) => {
+        await interceptDownload(page);
+        await page.addInitScript(() => {
+            const makeFile = (name, content) => {
+                const bytes = new TextEncoder().encode(content);
+                return {
+                    kind: 'file', name,
+                    getFile: async () => ({
+                        name, size: bytes.length, lastModified: Date.now(),
+                        text: async () => content,
+                        arrayBuffer: async () => bytes.buffer,
+                    }),
+                };
+            };
+            window.showDirectoryPicker = async () => ({
+                kind: 'directory', name: 'root',
+                values: async function* () { yield makeFile('notes.md', '# Notes'); },
+                getDirectoryHandle: async () => {
+                    throw new DOMException('not found', 'NotFoundError');
+                },
+            });
+        });
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-full"]');
+
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+        const filename = await page.evaluate(() => window.__capturedDownload.filename);
+
+        expect(filename).toMatch(/^gypsum-full-\d{8}-\d{6}\.tar\.gz$/);
+
+        // Archive should contain the content file even without .gypsum
+        const entryNames = await page.evaluate(async () => {
+            const { parseTarGzip } = await import('/public/js/backup/nanotar.js');
+            const buf = await window.__capturedDownload.blob.arrayBuffer();
+            const entries = await parseTarGzip(new Uint8Array(buf));
+            return entries.map(e => e.name);
+        });
+        expect(entryNames).toContain('notes.md');
+    });
+
+    test('backup buttons do nothing when no folder is loaded', async ({ page }) => {
+        await page.addInitScript(() => {
+            window.__downloadTriggered = false;
+            const origCreateObjectURL = URL.createObjectURL.bind(URL);
+            URL.createObjectURL = (blob) => {
+                window.__downloadTriggered = true;
+                return origCreateObjectURL(blob);
+            };
+            window.showOpenFilePicker = async () => [{
+                getFile: async () => ({
+                    name: 'notes.md', size: 8, lastModified: Date.now(),
+                    text: async () => '# Notes',
+                }),
+            }];
+        });
+
+        await page.goto('/');
+        await page.click('[data-click-loadfiles]');
+        await expect(page.locator('.note-grid')).toHaveCount(1);
+
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-content"]');
+        await page.waitForTimeout(500);
+
+        const triggered = await page.evaluate(() => window.__downloadTriggered);
+        expect(triggered).toBe(false);
+    });
+
+});


### PR DESCRIPTION
Two new buttons in the settings modal: "Content only" (exports all .txt/.md files preserving directory paths) and "Full backup" (same, plus all .gypsum files). Both use createTarGzipStream from nanotar.js for streaming compression and trigger a browser download named gypsum-{content|full}-YYYYMMDD-HHMMSS.tar.gz.

Includes 7 Playwright tests covering filename patterns, archive contents, missing .gypsum folder, and the no-op when no folder is loaded.

https://claude.ai/code/session_019Kt7vgLRxLSCAdpURJX5Ha