### PR TITLE
Move OPFS buttons from toolbar to settings modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,6 @@
   <div class="flex-row">
     <div>
       <button id="btn_loadDirectoryHandles" data-click-loadfolder>Folder</button>
-      <button id="btn-import-opfs" data-click-importtartoopfs>Import backup</button>
-      <button id="btn-load-opfs" data-click-loadopfs disabled>Open OPFS</button>
       <span id=fileCountElement>No files loaded</span>
     </div>
 
@@ -197,6 +195,14 @@
       <div class="settings-backup-btns">
         <button class="settings-action-btn" data-action="backup-content">Content only</button>
         <button class="settings-action-btn" data-action="backup-full">Full backup</button>
+      </div>
+    </div>
+
+    <div class="settings-row">
+      <span class="settings-label">Restore</span>
+      <div class="settings-backup-btns">
+        <button id="btn-import-opfs" data-click-importtartoopfs>Import backup</button>
+        <button id="btn-load-opfs" data-click-loadopfs disabled>Open OPFS</button>
       </div>
     </div>
 


### PR DESCRIPTION
Relocates "Import backup" and "Open OPFS" buttons into a new "Restore" row in the settings modal, directly below the existing "Backup" row.

https://claude.ai/code/session_01SBY4VV3EqZ1W6EE4gX75w4