### PR TITLE
fix computeColumnCount to use left position for grid-lanes compatibility

### DIFF
--- a/public/js/ui/ui-functions-click/keyboard-navigate.js
+++ b/public/js/ui/ui-functions-click/keyboard-navigate.js
@@ -10,15 +10,16 @@ let _cachedCols = 0;
 let _cachedRowsOnScreen = 0;
 
 /**
- * Computes the number of columns by finding the first element whose top edge
- * exceeds that of the first element (i.e. is on row 2).
+ * Computes the number of columns by finding the first element (after index 0)
+ * whose left edge matches that of the first element (i.e. is on row 2, column 0).
+ * Works for both standard CSS grid (row-first) and grid-lanes (column-first).
  * @param {Element[]} els
  * @returns {number}
  */
 function computeColumnCount(els) {
     if (els.length === 0) return 1;
-    const firstTop = els[0].getBoundingClientRect().top;
-    const cols = els.findIndex(el => el.getBoundingClientRect().top > firstTop);
+    const firstLeft = els[0].getBoundingClientRect().left;
+    const cols = els.findIndex((el, i) => i > 0 && el.getBoundingClientRect().left === firstLeft);
     return cols === -1 ? els.length : cols;
 }
 


### PR DESCRIPTION
The previous heuristic found the first element with a higher top than element 0 (i.e. the start of row 2). This breaks with grid-lanes, where items fill column-first so rows don't share a top value. Switching to matching the same left position works for both standard grid (row-first) and grid-lanes (column-first), since items that start a new row always share the left position of the first column.

https://claude.ai/code/session_01HWZzQpF6Ud9Y62gEYW1ZZZ