### PR TITLE
Fade load-folder-arrow in/out over 0.2s on loading state change

### DIFF
--- a/public/css/button-load.css
+++ b/public/css/button-load.css
@@ -44,8 +44,11 @@
 #load-folder-arrow {
     transform-box: fill-box;
     transform-origin: center;
+    stroke: transparent;
+    transition: stroke 0.2s;
 }
 
 #btn_loadDirectoryHandles.loading #load-folder-arrow {
     animation: load-folder-spin 1s linear infinite;
+    stroke: currentColor;
 }


### PR DESCRIPTION
stroke defaults to transparent and transitions to currentColor when .loading is applied, then back on removal. Prevents the arrow flashing in and out abruptly.

https://claude.ai/code/session_01XvQi3nXxhAi5q8WMbeMAAJ