### PR TITLE
Enforce 1s minimum loading class duration on all load paths

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -14,13 +14,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.querySelector('[data-click-loadfolder]').addEventListener('click', async () => {
         const btn = document.getElementById('btn_loadDirectoryHandles');
+        let minDuration;
         try {
             await loadDirectoryFileHandles(() => {
                 btn.classList.add('loading');
                 appState.myFiles = [];
                 renderFiles();
+                minDuration = new Promise(r => setTimeout(r, 1000));
             });
             postLoad();
+            await minDuration;
         } finally {
             btn.classList.remove('loading');
         }
@@ -38,11 +41,13 @@ document.addEventListener('DOMContentLoaded', function () {
         appState.myFiles = [];
         renderFiles();
         document.getElementById('fileCountElement').textContent = 'file: unpacking';
+        const minDuration = new Promise(r => setTimeout(r, 1000));
         const removeLoading = () => btn.classList.remove('loading');
         try {
-            await importTarGzipToOPFS(() => {
+            await importTarGzipToOPFS(async () => {
                 postLoad();
                 document.getElementById('btn-load-opfs').disabled = false;
+                await minDuration;
                 removeLoading();
             });
         } catch {
@@ -85,9 +90,11 @@ async function loadAndProcess(loaderFn) {
     btn.classList.add('loading');
     appState.myFiles = [];
     renderFiles();
+    const minDuration = new Promise(r => setTimeout(r, 1000));
     try {
         await loaderFn();
         postLoad();
+        await minDuration;
     } finally {
         btn.classList.remove('loading');
     }


### PR DESCRIPTION
A minDuration promise (setTimeout 1000ms) is created when the loading class is added. postLoad() fires immediately when files finish loading so the file list appears, but the class removal waits for Promise.all to resolve so the spinner always completes at least one full cycle and fades out cleanly.

https://claude.ai/code/session_01XvQi3nXxhAi5q8WMbeMAAJ