### PR TITLE
Blend per-row colour into column hover highlight

### DIFF
--- a/public/css/note-table.css
+++ b/public/css/note-table.css
@@ -103,5 +103,5 @@
 /* column hover — selector managed by table-col-hover.js */
 .note-table-header .note-table-cell-header:has([data-property=""]),
 .note-table-header ~ .note-table .note-table-cell[data-prop=""] {
-    background-color: var(--table-hover-bg);
+    background-color: color-mix(in oklch, attr(data-color type(<color>), var(--colour-neutral-alt)) 80%, var(--color-mono-contr, var(--colour-contr)));
 }

--- a/public/js/ui/ui-functions-table/render-table-rows.js
+++ b/public/js/ui/ui-functions-table/render-table-rows.js
@@ -51,7 +51,7 @@ export function renderTableRows(current_props, renderEverything) {
                         cellContent = value || '';
                         break;
                 }
-                return `<div class="note-table-cell keyboard-navigable" tabindex="0" data-index="${index}" data-prop="${prop.name}">${cellContent}</div>`;
+                return `<div class="note-table-cell keyboard-navigable" tabindex="0" data-index="${index}" data-prop="${prop.name}" data-color="${file.color}">${cellContent}</div>`;
             }).join('');
 
             // this is the "wrapper" div that contains the table row elements rendered above

--- a/public/js/ui/ui-functions-table/table-col-hover.js
+++ b/public/js/ui/ui-functions-table/table-col-hover.js
@@ -35,7 +35,7 @@ function updateColHoverRule(prop) {
     sheet.insertRule(
         `.note-table-header .note-table-cell-header:has([data-property=${val}]),` +
         `.note-table-header ~ .note-table .note-table-cell[data-prop=${val}]` +
-        `{ background-color: var(--table-hover-bg); }`,
+        `{ background-color: color-mix(in oklch, attr(data-color type(<color>), var(--colour-neutral-alt)) 80%, var(--color-mono-contr, var(--colour-contr))); }`,
         index
     );
 }


### PR DESCRIPTION
Adds data-color to each .note-table-cell so the column hover rule can use the same color-mix(attr(data-color ...) 80%, contrast) expression as the row hover. Each cell in the highlighted column now tints with its own row's file colour rather than a flat neutral.

https://claude.ai/code/session_01JUqGiUagb3NiTg7MQebXK8