### PR TITLE
Preserve original file mtime through tar backup/import cycle

### DIFF
--- a/public/js/backup/create-backup.js
+++ b/public/js/backup/create-backup.js
@@ -49,16 +49,20 @@ async function collectGypsumFiles(dirHandle) {
 }
 
 /**
- * Convert file handle entries to the { name, data } format nanotar expects.
+ * Convert file handle entries to the { name, data, attrs } format nanotar expects.
  * @param {Array<{handle: FileSystemFileHandle, filepath: string}>} fileEntries
- * @returns {Promise<Array<{name: string, data: Uint8Array}>>}
+ * @returns {Promise<Array<{name: string, data: Uint8Array, attrs: {mtime: number}}>>}
  */
 async function toTarEntries(fileEntries) {
     return Promise.all(
-        fileEntries.map(async ({ handle, filepath }) => ({
-            name: filepath,
-            data: new Uint8Array(await (await handle.getFile()).arrayBuffer()),
-        }))
+        fileEntries.map(async ({ handle, filepath }) => {
+            const file = await handle.getFile();
+            return {
+                name: filepath,
+                data: new Uint8Array(await file.arrayBuffer()),
+                attrs: { mtime: file.lastModified },
+            };
+        })
     );
 }
 

--- a/public/js/backup/opfs-import.js
+++ b/public/js/backup/opfs-import.js
@@ -64,6 +64,36 @@ async function writeFilesToOPFS(entries, opfsRoot, n, total) {
 }
 
 /**
+ * Persists a filepath→mtime (ms) map to .gypsum/mtime.json in OPFS.
+ * @param {Map<string, number>} mtimeMap
+ * @param {FileSystemDirectoryHandle} opfsRoot
+ * @returns {Promise<void>}
+ */
+async function writeMtimeMap(mtimeMap, opfsRoot) {
+    const gypsumDir = await opfsRoot.getDirectoryHandle('.gypsum', { create: true });
+    const fileHandle = await gypsumDir.getFileHandle('mtime.json', { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(JSON.stringify(Object.fromEntries(mtimeMap)));
+    await writable.close();
+}
+
+/**
+ * Reads .gypsum/mtime.json from OPFS. Returns null if absent.
+ * @param {FileSystemDirectoryHandle} opfsRoot
+ * @returns {Promise<Map<string, number>|null>}
+ */
+async function readMtimeMap(opfsRoot) {
+    try {
+        const gypsumDir = await opfsRoot.getDirectoryHandle('.gypsum', { create: false });
+        const fileHandle = await gypsumDir.getFileHandle('mtime.json', { create: false });
+        const file = await fileHandle.getFile();
+        return new Map(Object.entries(JSON.parse(await file.text())));
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Reads all .txt/.md files from OPFS and populates appState. Mirrors loadDirectoryFileHandles().
  * @param {FileSystemDirectoryHandle} opfsRoot
  * @param {number|null} outerStartTime - performance.now() timestamp from before unpacking, if available.
@@ -75,6 +105,7 @@ async function populateAppStateFromOPFS(opfsRoot, outerStartTime = null, n = nul
     appState.dirHandle = opfsRoot;
     document.getElementById('btn-new-note').disabled = false;
 
+    const mtimeMap = await readMtimeMap(opfsRoot);
     const startTime = performance.now();
 
     const fileEntries = await getFilesRecursive(opfsRoot);
@@ -92,7 +123,8 @@ async function populateAppStateFromOPFS(opfsRoot, outerStartTime = null, n = nul
         const fileObj = await getFileDataAndMetadata(handle, i);
         if (i % updateN === 0) fileCountEl.style.setProperty('--load-pct', Math.round(Math.min(100, pct += increment)));
         // if (i % updateN === 0) fileCountEl.textContent = `files: ${Math.round(Math.min(100, pct += increment))}% of ${total}`;
-        filesWithMetadata.push({ ...fileObj, filepath, id: filepath });
+        const lastModified = mtimeMap?.has(filepath) ? new Date(mtimeMap.get(filepath)) : fileObj.lastModified;
+        filesWithMetadata.push({ ...fileObj, filepath, id: filepath, lastModified });
     }
 
     appState.myFileHandlesMap = filesWithMetadata.reduce((map, fileObject) => {
@@ -127,10 +159,17 @@ export async function importTarGzipToOPFS(onComplete) {
     const entries = await parseTarGzip(await file.arrayBuffer());
     const opfsRoot = await navigator.storage.getDirectory();
 
+    const mtimeMap = new Map(
+        entries
+            .filter(e => e.type === 'file' && e.attrs?.mtime > 0)
+            .map(e => [e.name, e.attrs.mtime * 1000])
+    );
+
     async function proceed() {
         const total = entries.filter(e => e.type === 'file').length;
         const n = Math.max(1, Math.ceil(total * PROGRESS_STEP_SIZE / 100));
         await writeFilesToOPFS(entries, opfsRoot, n, total);
+        await writeMtimeMap(mtimeMap, opfsRoot);
         await populateAppStateFromOPFS(opfsRoot, importStartTime, n);
         onComplete();
     }

--- a/tests/25-tar-backup.spec.js
+++ b/tests/25-tar-backup.spec.js
@@ -188,4 +188,142 @@ test.describe('tar backup buttons', () => {
         expect(entryNames).toContain('.gypsum/notes-save.gypsum');
     });
 
+    test('backup tar entries carry the original lastModified timestamp', async ({ page }) => {
+        const FIXED_MTIME = new Date('2024-01-15T10:00:00Z').getTime();
+
+        await interceptDownload(page);
+        await page.addInitScript((fixedMtime) => {
+            const makeFile = (name, content) => {
+                const bytes = new TextEncoder().encode(content);
+                return {
+                    kind: 'file', name,
+                    getFile: async () => ({
+                        name,
+                        size: bytes.length,
+                        lastModified: fixedMtime,
+                        text: async () => content,
+                        arrayBuffer: async () => bytes.buffer,
+                    }),
+                };
+            };
+            window.showDirectoryPicker = async () => ({
+                kind: 'directory', name: 'root',
+                values: async function* () {
+                    yield makeFile('notes.txt', 'Fixed mtime note');
+                },
+                getDirectoryHandle: async () => { throw new DOMException('not found', 'NotFoundError'); },
+            });
+        }, FIXED_MTIME);
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-content"]');
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+
+        const storedMtimeSec = await page.evaluate(async () => {
+            const { parseTarGzip } = await import('/public/js/backup/nanotar.js');
+            const buf = await window.__capturedDownload.blob.arrayBuffer();
+            const entries = await parseTarGzip(new Uint8Array(buf));
+            return entries.find(e => e.name === 'notes.txt')?.attrs?.mtime;
+        });
+
+        // nanotar writes mtime in seconds (truncated from ms), so allow ±1s rounding
+        expect(storedMtimeSec * 1000).toBeCloseTo(FIXED_MTIME, -3);
+    });
+
+    test('mtime.json is written to OPFS during import with correct timestamps', async ({ page }) => {
+        const FIXED_MTIME = new Date('2023-06-20T08:30:00Z').getTime();
+
+        await interceptDownload(page);
+
+        // Both the directory picker mock and the OPFS mock must be in addInitScript
+        // so they are present from the very start of the page load.
+        await page.addInitScript((fixedMtime) => {
+            const makeFile = (name, content) => {
+                const bytes = new TextEncoder().encode(content);
+                return {
+                    kind: 'file', name,
+                    getFile: async () => ({
+                        name, size: bytes.length, lastModified: fixedMtime,
+                        text: async () => content,
+                        arrayBuffer: async () => bytes.buffer,
+                    }),
+                };
+            };
+            window.showDirectoryPicker = async () => ({
+                kind: 'directory', name: 'root',
+                values: async function* () { yield makeFile('article.md', '# Article\nContent'); },
+                getDirectoryHandle: async () => { throw new DOMException('not found', 'NotFoundError'); },
+            });
+
+            // OPFS mock — flat map records all written files keyed by full path
+            const opfsFiles = {};
+            window.__opfsFiles = opfsFiles;
+
+            function makeWritable(path) {
+                let content = '';
+                return {
+                    write: async (data) => { content += typeof data === 'string' ? data : new TextDecoder().decode(data); },
+                    close: async () => { opfsFiles[path] = content; },
+                };
+            }
+
+            function makeDirHandle(prefix) {
+                return {
+                    keys: async function* () {},
+                    // values() enumerates files written at this prefix level so getFilesRecursive works
+                    values: async function* () {
+                        for (const path of Object.keys(opfsFiles)) {
+                            if (!path.startsWith(prefix)) continue;
+                            const rel = path.slice(prefix.length);
+                            if (rel.includes('/')) continue;
+                            if (!rel.endsWith('.md') && !rel.endsWith('.txt')) continue;
+                            const text = opfsFiles[path];
+                            yield {
+                                kind: 'file', name: rel,
+                                getFile: async () => ({
+                                    name: rel, lastModified: fixedMtime,
+                                    text: async () => text,
+                                    arrayBuffer: async () => new TextEncoder().encode(text).buffer,
+                                }),
+                            };
+                        }
+                    },
+                    removeEntry: async () => {},
+                    getDirectoryHandle: async (name) => makeDirHandle(`${prefix}${name}/`),
+                    getFileHandle: async (name) => ({
+                        createWritable: async () => makeWritable(`${prefix}${name}`),
+                        getFile: async () => {
+                            const text = opfsFiles[`${prefix}${name}`];
+                            if (text === undefined) throw new DOMException('not found', 'NotFoundError');
+                            return { text: async () => text, lastModified: fixedMtime, arrayBuffer: async () => new TextEncoder().encode(text).buffer };
+                        },
+                    }),
+                };
+            }
+            navigator.storage.getDirectory = async () => makeDirHandle('');
+        }, FIXED_MTIME);
+
+        await page.goto('/');
+        await page.click('[data-click-loadfolder]');
+        await page.click('[data-action="open-settings-modal"]');
+        await page.click('[data-action="backup-content"]');
+        await page.waitForFunction(() => window.__capturedDownload?.filename != null);
+
+        const mtimeJson = await page.evaluate(async () => {
+            const tarBytes = new Uint8Array(await window.__capturedDownload.blob.arrayBuffer());
+            window.showOpenFilePicker = async () => [{ getFile: async () => ({ arrayBuffer: async () => tarBytes.buffer }) }];
+
+            const { importTarGzipToOPFS } = await import('/public/js/backup/opfs-import.js');
+            await importTarGzipToOPFS(() => {});
+
+            return window.__opfsFiles['.gypsum/mtime.json'] ?? null;
+        });
+
+        expect(mtimeJson).not.toBeNull();
+        const parsed = JSON.parse(mtimeJson);
+        expect(parsed['article.md']).toBeCloseTo(FIXED_MTIME, -3);
+    });
+
 });


### PR DESCRIPTION
When importing a tar.gz backup, the File System Access API sets all OPFS file mtimes to the import time. Fix this by:

- Including attrs.mtime in tar entries during backup (create-backup.js)
- Building a filepath→mtime map from tar entry headers after parse
- Writing that map to .gypsum/mtime.json in OPFS after extraction
- Reading mtime.json in populateAppStateFromOPFS() and using stored dates

The sidecar file persists across page refreshes, so "Open OPFS" after a reload also shows original dates rather than the import timestamp.

https://claude.ai/code/session_01Y47AZYhvZoAiqS73zAmKVh