### PR TITLE
Fix import backup not clearing old OPFS content

### DIFF
--- a/public/js/backup/opfs-import.js
+++ b/public/js/backup/opfs-import.js
@@ -27,7 +27,9 @@ async function hasOPFSContent(opfsRoot) {
  * @returns {Promise<void>}
  */
 async function clearOPFS(opfsRoot) {
-    for await (const name of opfsRoot.keys()) {
+    const names = [];
+    for await (const name of opfsRoot.keys()) names.push(name);
+    for (const name of names) {
         await opfsRoot.removeEntry(name, { recursive: true });
     }
 }
@@ -187,13 +189,11 @@ export async function importTarGzipToOPFS(onComplete) {
     }
 
     if (await hasOPFSContent(opfsRoot)) {
-        showWarningModal('OPFS already contains imported files. Overwrite them?', 'Overwrite', 'Cancel', async () => {
-            await clearOPFS(opfsRoot);
-            await proceed();
-        });
-    } else {
-        await proceed();
+        const confirmed = await showWarningModal('OPFS already contains imported files. Overwrite them?', 'Overwrite', 'Cancel');
+        if (!confirmed) throw new DOMException('', 'AbortError');
+        await clearOPFS(opfsRoot);
     }
+    await proceed();
 }
 
 /**

--- a/public/js/ui/ui-functions-click/delete-file-click.js
+++ b/public/js/ui/ui-functions-click/delete-file-click.js
@@ -85,7 +85,7 @@ async function handleDeleteFileConfirmed() {
  * Shows a confirmation warning before proceeding.
  * @param {Event} evt
  */
-export function handleDeleteFile(evt) {
+export async function handleDeleteFile(evt) {
     evt.preventDefault();
     if (!appState.dirHandle) return;
 
@@ -93,10 +93,7 @@ export function handleDeleteFile(evt) {
     const file = appState.myFiles.find(f => f.id === fileId);
     if (!file) return;
 
-    showWarningModal(
-        `Move "${file.filename}" to trash?`,
-        'Delete',
-        'Cancel',
-        handleDeleteFileConfirmed,
-    );
+    if (await showWarningModal(`Move "${file.filename}" to trash?`, 'Delete', 'Cancel')) {
+        handleDeleteFileConfirmed();
+    }
 }

--- a/public/js/ui/ui-functions-click/open-file-content-view-trans.js
+++ b/public/js/ui/ui-functions-click/open-file-content-view-trans.js
@@ -199,10 +199,12 @@ export function doClose() {
  * Shows the unsaved changes warning dialog if there are unsaved edits.
  * @returns {void}
  */
-export function handleCloseModal() {
+export async function handleCloseModal() {
 
   if (hasUnsavedChanges()) {
-    showWarningModal('You have unsaved changes', 'Discard changes', 'Keep editing', doClose);
+    if (await showWarningModal('You have unsaved changes', 'Discard changes', 'Keep editing')) {
+      doClose();
+    }
     return;
   }
   doClose();

--- a/public/js/ui/ui-functions-click/warning-modal.js
+++ b/public/js/ui/ui-functions-click/warning-modal.js
@@ -1,7 +1,7 @@
 /**
- * @file Configurable warning/confirmation modal. A single module-level callback
- * is stored so the same dialog element can be reused for different confirm flows
- * (e.g. "close with unsaved changes" and "delete file").
+ * @file Configurable warning/confirmation modal. A single module-level resolve
+ * function is stored so the same dialog element can be reused for different
+ * confirm flows (e.g. "close with unsaved changes", "delete file", "overwrite OPFS").
  */
 
 const warningDialog = document.getElementById('modal-unsaved-warning');
@@ -9,39 +9,42 @@ const warningText   = document.getElementById('modal-unsaved-warning-text');
 const proceedBtn    = document.getElementById('modal-unsaved-warning-proceed');
 const cancelBtn     = document.getElementById('modal-unsaved-warning-cancel');
 
-let pendingCallback = null;
+let pendingResolve = null;
 
 /**
  * Populates and shows the warning dialog.
  * @param {string} mainText - Body text of the warning.
  * @param {string} proceedText - Label for the destructive-action button.
  * @param {string} cancelText - Label for the cancel button.
- * @param {Function} onProceed - Called (synchronously) when the proceed button is clicked.
+ * @returns {Promise<boolean>} Resolves true if the user clicked proceed, false if cancelled.
  */
-export function showWarningModal(mainText, proceedText, cancelText, onProceed) {
-    warningText.textContent  = mainText;
-    proceedBtn.textContent   = proceedText;
-    cancelBtn.textContent    = cancelText;
-    pendingCallback = onProceed;
-    warningDialog.showModal();
-    warningDialog.focus();
+export function showWarningModal(mainText, proceedText, cancelText) {
+    warningText.textContent = mainText;
+    proceedBtn.textContent  = proceedText;
+    cancelBtn.textContent   = cancelText;
+    return new Promise(resolve => {
+        pendingResolve = resolve;
+        warningDialog.showModal();
+        warningDialog.focus();
+    });
 }
 
 /**
- * Handles the proceed button click: closes the dialog and fires the stored callback.
+ * Handles the proceed button click: closes the dialog and resolves the promise.
  */
 export function handleWarningProceed() {
     warningDialog.close();
-    const cb = pendingCallback;
-    pendingCallback = null;
-    cb?.();
+    const resolve = pendingResolve;
+    pendingResolve = null;
+    resolve?.(true);
 }
 
 /**
- * Handles the cancel button click: closes the dialog and discards the stored callback.
+ * Handles the cancel button click: closes the dialog and resolves the promise.
  */
 export function handleWarningCancel() {
     warningDialog.close();
-    pendingCallback = null;
-    document.getElementById('btn_loadDirectoryHandles').classList.remove('loading');
+    const resolve = pendingResolve;
+    pendingResolve = null;
+    resolve?.(false);
 }

--- a/public/main.js
+++ b/public/main.js
@@ -52,7 +52,9 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         } catch (err) {
             removeLoading();
-            document.getElementById('fileCountElement').textContent = err?.message ?? '';
+            if (err?.name !== 'AbortError') {
+                document.getElementById('fileCountElement').textContent = err?.message ?? '';
+            }
         }
     });
 


### PR DESCRIPTION
Two bugs caused the import-backup flow to show stale OPFS files instead
of the newly imported ones.

Primary bug: importTarGzipToOPFS called showWarningModal fire-and-forget
when OPFS already had content. The await in main.js resolved immediately
(before the user even dismissed the modal), making the proceed/clear/write
pipeline run as an unawaited async callback whose errors were silently
swallowed. Convert showWarningModal to return a Promise<boolean> so the
caller can await the user's choice, then clear and proceed sequentially
in the same async chain. Cancel now throws AbortError so main.js cleans
up via the existing catch block.

Secondary bug: clearOPFS iterated opfsRoot.keys() while deleting entries.
The live cursor shifted as entries were removed, causing alternate entries
to be skipped. Fix by snapshotting all keys into an array first, then
deleting.

Also suppress the AbortError message in fileCountElement (covers both
file-picker cancel and modal cancel).

https://claude.ai/code/session_01Po4Hkqz21vnyrLVYPoAXtP