### PR TITLE
Replace text size number inputs with S/M/L radio buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,9 @@
     <div class="settings-row">
       <span class="settings-label">Text size adjust</span>
       <div class="settings-control-group">
-        <input type="number" class="settings-number-input" min="0.5" max="2" step="0.1" value="1" data-action="font-size-app-change">
+        <label class="formcontrol"><input type="radio" name="font-size-app" value="0.8" data-action="font-size-app-change">S</label>
+        <label class="formcontrol"><input type="radio" name="font-size-app" value="1" checked data-action="font-size-app-change">M</label>
+        <label class="formcontrol"><input type="radio" name="font-size-app" value="1.2" data-action="font-size-app-change">L</label>
         <button class="settings-reset-btn" data-action="reset-font-size-app">↺</button>
       </div>
     </div>
@@ -257,7 +259,9 @@
     <div class="settings-row">
       <span class="settings-label">Text size adjust</span>
       <div class="settings-control-group">
-        <input type="number" class="settings-number-input" min="0.5" max="2" step="0.1" value="1" data-action="font-size-file-change">
+        <label class="formcontrol"><input type="radio" name="font-size-file" value="0.8" data-action="font-size-file-change">S</label>
+        <label class="formcontrol"><input type="radio" name="font-size-file" value="1" checked data-action="font-size-file-change">M</label>
+        <label class="formcontrol"><input type="radio" name="font-size-file" value="1.2" data-action="font-size-file-change">L</label>
         <button class="settings-reset-btn" data-action="reset-font-size-file">↺</button>
       </div>
     </div>

--- a/public/js/ui/ui-functions-click/font-settings.js
+++ b/public/js/ui/ui-functions-click/font-settings.js
@@ -20,29 +20,17 @@ const DEFAULTS = {
 // ── Font size ──────────────────────────────────────────────────────────────
 
 /**
- * Clamps a font size multiplier to [0.5, 2] rounded to 1 decimal place.
- * @param {string} raw
- * @returns {string}
- */
-function clampFontSize(raw) {
-    const n = Math.min(2, Math.max(0.5, parseFloat(raw) || 1));
-    return Math.round(n * 10) / 10 + '';
-}
-
-/**
- * Sets a font-size CSS variable and syncs the input element's displayed value.
+ * Sets a font-size CSS variable from a radio button's value.
  * @param {HTMLInputElement} el
  * @param {string} cssVar
  * @returns {void}
  */
 function setFontSize(el, cssVar) {
-    const value = clampFontSize(el.value);
-    el.value = value;
-    root.style.setProperty(cssVar, value);
+    root.style.setProperty(cssVar, el.value);
 }
 
 /**
- * Resets a font-size CSS variable to its default and updates the number input.
+ * Resets a font-size CSS variable to its default and checks the matching radio button.
  * @param {string} cssVar
  * @param {string} action
  * @param {string} defaultValue
@@ -50,8 +38,8 @@ function setFontSize(el, cssVar) {
  */
 function resetFontSize(cssVar, action, defaultValue) {
     root.style.setProperty(cssVar, defaultValue);
-    const input = document.querySelector(`[data-action="${action}"]`);
-    if (input) input.value = defaultValue;
+    const radio = document.querySelector(`[data-action="${action}"][value="${defaultValue}"]`);
+    if (radio) radio.checked = true;
 }
 
 /**


### PR DESCRIPTION
Simplifies the Interface and Text files "Text size adjust" settings from free-form number inputs to fixed three-option radio groups (S=0.8, M=1, L=1.2). Removes the clamp/round helper and input-value sync since values are now constrained by the UI. The reset handler is updated to check the matching radio button rather than setting a value property.

https://claude.ai/code/session_01WVLbZLTjhtVHFgUuwdghY3