### PR TITLE
Replace button size select with radio inputs (M/L)

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,10 +249,8 @@
     <div class="settings-row">
       <span class="settings-label">Button size</span>
       <div class="settings-control-group">
-        <select data-action="button-size-change">
-          <option value="1">normal</option>
-          <option value="1.2">large</option>
-        </select>
+        <label><input type="radio" name="button-size" data-action="button-size-change" value="1" checked> M</label>
+        <label><input type="radio" name="button-size" data-action="button-size-change" value="1.2"> L</label>
         <button class="settings-reset-btn" data-action="reset-button-size">↺</button>
       </div>
     </div>

--- a/public/js/ui/ui-functions-click/button-size.js
+++ b/public/js/ui/ui-functions-click/button-size.js
@@ -10,7 +10,7 @@ const DEFAULT_MULTIPLE = getComputedStyle(root).getPropertyValue('--btn-size-mul
 
 /**
  * @param {Event} _evt
- * @param {HTMLSelectElement} el
+ * @param {HTMLInputElement} el
  * @returns {void}
  */
 export function handleButtonSizeChange(_evt, el) {
@@ -22,6 +22,6 @@ export function handleButtonSizeChange(_evt, el) {
  */
 export function handleResetButtonSize() {
     root.style.setProperty('--btn-size-multiple', DEFAULT_MULTIPLE);
-    const select = document.querySelector('[data-action="button-size-change"]');
-    if (select) select.value = DEFAULT_MULTIPLE;
+    const radio = document.querySelector(`[data-action="button-size-change"][value="${DEFAULT_MULTIPLE}"]`);
+    if (radio) radio.checked = true;
 }


### PR DESCRIPTION
Swaps the <select> in the settings dialog for two native radio buttons labelled M and L. Updates handleResetButtonSize to check the matching radio rather than setting .value on a select element.

https://claude.ai/code/session_014tTRXnsYeXMBTSohfngWVp