### PR TITLE
Trigger search immediately when selecting tag from searchbox autocomp…

### DIFF
--- a/public/js/autocomplete/tag-autocomplete.js
+++ b/public/js/autocomplete/tag-autocomplete.js
@@ -4,6 +4,7 @@ import { detectEditorTrigger, detectSearchboxTrigger, filterTags } from './tag-q
 import { createPopup, repopulatePopup, destroyPopup, moveActiveItem } from './tag-popup.js';
 import { handlePopupKeydown } from './tag-keyboard-nav.js';
 import { replaceEditorTag, replaceSearchboxTag } from './tag-replace.js';
+import { handleSearchBoxClick } from '../ui/ui-functions-click/searchbox-search-click.js';
 
 let _popup = null;          // HTMLElement|null
 let _context = null;        // 'editor'|'searchbox'|null
@@ -148,8 +149,10 @@ function _applySelection(tag) {
         replaceSearchboxTag(_anchorEl, tag, _triggerStart);
     }
     const anchor = _anchorEl;
+    const wasSearchbox = _context === 'searchbox';
     _dismiss();
     anchor?.focus();
+    if (wasSearchbox) handleSearchBoxClick();
 }
 
 function _dismiss() {

--- a/tests/22-tag-autocomplete.spec.js
+++ b/tests/22-tag-autocomplete.spec.js
@@ -186,14 +186,15 @@ test.describe('tag autocomplete — searchbox', () => {
     await expect(page.locator('.tag-autocomplete-popup')).toContainText('personal');
   });
 
-  test('clicking an item fills the searchbox value', async ({ page }) => {
+  test('clicking an item triggers the search immediately', async ({ page }) => {
     await setupMockFiles(page);
     await page.goto('/');
     await loadFiles(page);
     await page.fill('#searchbox', 'tags:p');
     await page.locator('.tag-autocomplete-item').filter({ hasText: 'personal' }).click();
     await expect(page.locator('.tag-autocomplete-popup')).not.toBeVisible();
-    await expect(page.locator('#searchbox')).toHaveValue('tags:personal');
+    // shopping.txt and big-ideas.md both have #personal
+    await expect(page.locator('.note-grid')).toHaveCount(2);
   });
 
   test('Enter with no active item dismisses popup and runs search', async ({ page }) => {


### PR DESCRIPTION
…lete

Selecting a tag from the autocomplete in the search box now calls handleSearchBoxClick() directly, so the results appear without requiring a separate Enter press. Updated the test that previously checked the searchbox retained its typed value (no longer accurate since the search clears the box) to instead assert that 2 matching files appear in the grid.