### PR TITLE
Fix settings modal closing on dialog background click

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
     <div id="output"></div>
   </main>
 
-  <dialog id="modal-settings" data-action="close-settings-outside">
+  <dialog id="modal-settings" closedby="any">
     <button class="modal-close-btn" data-action="close-settings-modal">✕</button>
 
     <h2 class="menu-title">Menu</h2>

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -23,7 +23,7 @@ import { handleHistorySelectChange } from './ui-functions-click/history-select-c
 import { handleSaveFileCopy } from './ui-functions-click/save-file-copy.js';
 import { handlePageChange } from './pagination/handle-page-change.js';
 import { handleKeyboardShortcuts } from './ui-functions-click/keyboard-shortcuts.js';
-import { handleOpenSettings, handleCloseSettings, handleCloseSettingsOutside } from './ui-functions-click/settings-modal.js';
+import { handleOpenSettings, handleCloseSettings } from './ui-functions-click/settings-modal.js';
 import { handleEditorUndo } from './ui-functions-click/editor-undo.js';
 import { handleEditorRedo } from './ui-functions-click/editor-redo.js';
 import { handleEditorColorPick, handleColorCirclePick, handleCloseColorPickerOutside, captureEditorCursorOffset } from './ui-functions-click/editor-color-pick.js';
@@ -85,7 +85,6 @@ const clickActionHandlers = {
     'change-page': handlePageChange,
     'open-settings-modal': handleOpenSettings,
     'close-settings-modal': handleCloseSettings,
-    'close-settings-outside': handleCloseSettingsOutside,
     'editor-undo': handleEditorUndo,
     'editor-redo': handleEditorRedo,
     'editor-color-pick': handleEditorColorPick,

--- a/public/js/ui/ui-functions-click/settings-modal.js
+++ b/public/js/ui/ui-functions-click/settings-modal.js
@@ -5,11 +5,6 @@ import { PAGINATION_SIZE } from '../../constants.js';
 
 const dialog = document.getElementById('modal-settings');
 
-let pressedOnBackdrop = false;
-dialog.addEventListener('pointerdown', (evt) => {
-    pressedOnBackdrop = evt.target === dialog;
-});
-
 /**
  * Opens the Settings modal.
  * @returns {void}
@@ -28,15 +23,3 @@ export function handleCloseSettings() {
     dialog.close();
 }
 
-/**
- * Closes the Settings modal when the user clicks on the backdrop.
- * Requires both the press and release to be on the dialog backdrop so that
- * a drag starting inside the modal doesn't accidentally close it.
- * @param {Event} event - The click event.
- * @returns {void}
- */
-export function handleCloseSettingsOutside(event) {
-    if (event.target === dialog && pressedOnBackdrop) {
-        dialog.close();
-    }
-}


### PR DESCRIPTION
Use the native closedby="any" attribute instead of custom JS backdrop detection. The old approach used evt.target === dialog which is true for both the real backdrop and the dialog's own padding area, causing the modal to close when clicking inside the coloured border area.

https://claude.ai/code/session_01LToY2C2WMUTX5PygNCzWas