### PR TITLE
Exclude contentPeek from all-properties search

### DIFF
--- a/public/js/services/store.js
+++ b/public/js/services/store.js
@@ -29,7 +29,7 @@ export const appState = {
         onlyProperties: " press / for search "
       }
     },
-    excludedProperties: ["handle", "show"],
+    excludedProperties: ["handle", "show", "contentPeek"],
     filters: new Map(),
     results: new Map(),
     matchingFiles: new Map()


### PR DESCRIPTION
contentPeek duplicates the dedicated content search, so matching against it in all-properties mode produces confusing results.

https://claude.ai/code/session_01BEU9FW4zdm4ZFRqAuwEMsj