### PR TITLE
Check manifest version before re-downloading the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,10 @@ the matching browser binary.
   non-obvious.
 - **Do not add error handling for impossible cases.** Trust the app's internal invariants.
   Only validate at genuine system boundaries (user input, File System API responses).
+- **Bump the manifest version on every change.** `manifest.json`'s `version` field drives
+  the service worker's cache-invalidation check (see `service-worker.js`). Any code change
+  must bump the **minor** version (e.g. `1.0.0` → `1.1.0`) by default, unless the user
+  explicitly asks for a different bump (major or patch).
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
+  "version": "1.0.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'gypsum-v1';
+const CACHE_NAME = 'gypsum-v1'; // stable bucket name — invalidation is now driven by
+                                // manifest.json's version field, not this constant.
 const PRECACHE_URLS = ['./', './public/style.css', './public/main.js', './manifest.json'];
 
 self.addEventListener('install', (event) => {
@@ -9,32 +10,67 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    Promise.all([
-      self.clients.claim(),
-      caches.keys().then((keys) =>
-        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-      ),
-    ])
-  );
+  event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener('fetch', (event) => {
-  // Only handle same-origin GET requests
-  if (event.request.method !== 'GET') return;
-  if (!event.request.url.startsWith(self.location.origin)) return;
+// True if the cached manifest.json has a different version than the one just fetched
+// from the network — or if nothing is cached yet (first install).
+async function versionHasChanged(cache, freshManifest) {
+  const cached = await cache.match('./manifest.json');
+  if (!cached) return true;
+  const cachedManifest = await cached.json();
+  return cachedManifest.version !== freshManifest.version;
+}
 
-  event.respondWith(
-    fetch(event.request)
-      .then((response) => {
-        // Network succeeded — update the cache and return the fresh response
-        const clone = response.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-        return response;
-      })
-      .catch(() =>
-        // Network failed — serve from cache if available
-        caches.match(event.request)
-      )
-  );
+// Re-fetches the precache set fresh (bypassing HTTP cache) and only then wipes the old
+// cache — if any fetch fails, the existing (working, offline-safe) cache is left untouched
+// and the update is simply retried on the next navigation. Stale JS modules under
+// public/js/** (never listed in PRECACHE_URLS) get evicted by the wipe too; they're
+// repopulated on demand by handleAsset() as the page re-imports them.
+async function refreshPrecache(cache, manifestResponse) {
+  const otherUrls = PRECACHE_URLS.filter((url) => url !== './manifest.json');
+  const otherResponses = await Promise.all(otherUrls.map((url) => fetch(url, { cache: 'no-store' })));
+
+  await Promise.all((await cache.keys()).map((req) => cache.delete(req)));
+  await cache.put('./manifest.json', manifestResponse);
+  await Promise.all(otherUrls.map((url, i) => cache.put(url, otherResponses[i])));
+}
+
+// Runs once per navigation: cheap manifest.json check, full refresh only on a version bump.
+async function handleNavigate(request) {
+  const cache = await caches.open(CACHE_NAME);
+
+  try {
+    const manifestResponse = await fetch('./manifest.json', { cache: 'no-store' });
+    const freshManifest = await manifestResponse.clone().json();
+    if (await versionHasChanged(cache, freshManifest)) {
+      await refreshPrecache(cache, manifestResponse);
+    }
+  } catch {
+    // Offline, or the check/refresh failed — fall through and serve whatever is cached.
+  }
+
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  return (await cache.match('./')) || fetch(request);
+}
+
+// Cache-first for everything else: correct because handleNavigate above already
+// guarantees the cache is current as of this navigation.
+async function handleAsset(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+  cache.put(request, response.clone());
+  return response;
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+  if (!request.url.startsWith(self.location.origin)) return;
+
+  event.respondWith(request.mode === 'navigate' ? handleNavigate(request) : handleAsset(request));
 });

--- a/tests/pwa.spec.js
+++ b/tests/pwa.spec.js
@@ -47,3 +47,72 @@ test('app falls back to cache when offline', async ({ page, context }) => {
   // Assert a real app UI element rendered, not just that <body> exists
   await expect(page.locator('#btn_loadDirectoryHandles')).toBeVisible();
 });
+
+// Validates the manifest-version check: an unchanged version must not trigger a
+// re-fetch of cached assets. Tampering with a cached asset and confirming it survives
+// a reload proves the service worker served it from cache untouched.
+test('unchanged manifest version serves assets from cache untouched', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() =>
+    new Promise((resolve) => {
+      if (navigator.serviceWorker.controller) return resolve();
+      navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
+    })
+  );
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  await page.evaluate(async () => {
+    const cache = await caches.open((await caches.keys())[0]);
+    const original = await cache.match('./public/style.css');
+    const text = await original.text();
+    await cache.put('./public/style.css', new Response(`${text}\n/* tampered */`, { headers: original.headers }));
+  });
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const cachedText = await page.evaluate(async () => {
+    const cache = await caches.open((await caches.keys())[0]);
+    return (await cache.match('./public/style.css')).text();
+  });
+  expect(cachedText).toContain('/* tampered */');
+});
+
+// Validates the other half of the manifest-version check: a bumped version must
+// trigger a real refresh, overwriting stale cached assets.
+test('bumped manifest version refreshes cached assets', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() =>
+    new Promise((resolve) => {
+      if (navigator.serviceWorker.controller) return resolve();
+      navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
+    })
+  );
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  // Force a mismatch: lower the cached manifest's version, and tamper with a cached
+  // asset so we can detect whether the refresh overwrites it.
+  await page.evaluate(async () => {
+    const cache = await caches.open((await caches.keys())[0]);
+
+    const manifestResponse = await cache.match('./manifest.json');
+    const manifest = await manifestResponse.json();
+    manifest.version = '0.0.0';
+    await cache.put('./manifest.json', new Response(JSON.stringify(manifest), { headers: manifestResponse.headers }));
+
+    const cssResponse = await cache.match('./public/style.css');
+    const text = await cssResponse.text();
+    await cache.put('./public/style.css', new Response(`${text}\n/* stale */`, { headers: cssResponse.headers }));
+  });
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const cachedText = await page.evaluate(async () => {
+    const cache = await caches.open((await caches.keys())[0]);
+    return (await cache.match('./public/style.css')).text();
+  });
+  expect(cachedText).not.toContain('/* stale */');
+});


### PR DESCRIPTION
Replace the network-first-for-everything caching strategy with a version-aware one: on each navigation, fetch only manifest.json and compare its version to the cached copy. A full asset refresh only happens when the version has actually changed; otherwise everything serves from cache, avoiding a full re-download (0.4MB+) on every load. Offline fallback is preserved. Also document that code changes should bump the manifest's minor version by default, since that now drives cache invalidation.


Claude-Session: https://claude.ai/code/session_01Wtg7CtDQYPDfDnZZJBCzm7