### PR TITLE
Serve app from cache first, check manifest version in the background

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,6 +399,9 @@
 <script>
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./service-worker.js');
+    navigator.serviceWorker.addEventListener('message', (event) => {
+      if (event.data?.type === 'gypsum-update-ready') location.reload();
+    });
   }
 </script>
 <script type="module" src="public/main.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/service-worker.js
+++ b/service-worker.js
@@ -36,8 +36,11 @@ async function refreshPrecache(cache, manifestResponse) {
   await Promise.all(otherUrls.map((url, i) => cache.put(url, otherResponses[i])));
 }
 
-// Runs once per navigation: cheap manifest.json check, full refresh only on a version bump.
-async function handleNavigate(request) {
+// Runs in the background, after a navigation has already been served from cache. Checks
+// manifest.json on the network; on a version bump, refreshes the cache and tells open tabs
+// to reload. The app's existing beforeunload/unsaved-changes guard protects in-progress
+// edits when that reload actually happens.
+async function checkForUpdate() {
   const cache = await caches.open(CACHE_NAME);
 
   try {
@@ -45,18 +48,24 @@ async function handleNavigate(request) {
     const freshManifest = await manifestResponse.clone().json();
     if (await versionHasChanged(cache, freshManifest)) {
       await refreshPrecache(cache, manifestResponse);
+      const clients = await self.clients.matchAll({ type: 'window' });
+      clients.forEach((client) => client.postMessage({ type: 'gypsum-update-ready' }));
     }
   } catch {
-    // Offline, or the check/refresh failed — fall through and serve whatever is cached.
+    // Offline, or the check/refresh failed — the next navigation just retries.
   }
-
-  const cached = await cache.match(request);
-  if (cached) return cached;
-  return (await cache.match('./')) || fetch(request);
 }
 
-// Cache-first for everything else: correct because handleNavigate above already
-// guarantees the cache is current as of this navigation.
+// Serves immediately from cache when available; only touches the network on a cache miss
+// (e.g. the very first visit, before anything is precached).
+async function handleNavigate(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  return fetch(request);
+}
+
+// Cache-first for everything else.
 async function handleAsset(request) {
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(request);
@@ -72,5 +81,11 @@ self.addEventListener('fetch', (event) => {
   if (request.method !== 'GET') return;
   if (!request.url.startsWith(self.location.origin)) return;
 
-  event.respondWith(request.mode === 'navigate' ? handleNavigate(request) : handleAsset(request));
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigate(request));
+    event.waitUntil(checkForUpdate());
+    return;
+  }
+
+  event.respondWith(handleAsset(request));
 });

--- a/tests/pwa.spec.js
+++ b/tests/pwa.spec.js
@@ -80,8 +80,10 @@ test('unchanged manifest version serves assets from cache untouched', async ({ p
 });
 
 // Validates the other half of the manifest-version check: a bumped version must
-// trigger a real refresh, overwriting stale cached assets.
-test('bumped manifest version refreshes cached assets', async ({ page }) => {
+// trigger a real refresh, overwriting stale cached assets, and reload the page.
+// The check now runs in the background after the page is served from cache, so we
+// poll the cache rather than asserting immediately after reload() resolves.
+test('bumped manifest version refreshes cached assets and reloads the page', async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() =>
     new Promise((resolve) => {
@@ -93,7 +95,7 @@ test('bumped manifest version refreshes cached assets', async ({ page }) => {
   await page.waitForLoadState('networkidle');
 
   // Force a mismatch: lower the cached manifest's version, and tamper with a cached
-  // asset so we can detect whether the refresh overwrites it.
+  // asset so we can detect whether the background refresh overwrites it.
   await page.evaluate(async () => {
     const cache = await caches.open((await caches.keys())[0]);
 
@@ -107,12 +109,17 @@ test('bumped manifest version refreshes cached assets', async ({ page }) => {
     await cache.put('./public/style.css', new Response(`${text}\n/* stale */`, { headers: cssResponse.headers }));
   });
 
+  // This reload is served instantly from the (tampered) cache; checkForUpdate then runs
+  // in the background, refreshes the cache, and messages the page to reload a second time.
   await page.reload();
-  await page.waitForLoadState('networkidle');
 
-  const cachedText = await page.evaluate(async () => {
+  await page.waitForFunction(async () => {
     const cache = await caches.open((await caches.keys())[0]);
-    return (await cache.match('./public/style.css')).text();
-  });
-  expect(cachedText).not.toContain('/* stale */');
+    const res = await cache.match('./public/style.css');
+    const text = await res.text();
+    return !text.includes('/* stale */');
+  }, { timeout: 10000 });
+
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('#btn_loadDirectoryHandles')).toBeVisible();
 });


### PR DESCRIPTION
Move the manifest.json version check out of the request-blocking path: navigations now serve instantly from cache, while a background check refreshes the cache and messages open tabs to reload only when a version bump is actually detected. This trades one reload-cycle of freshness lag for near-zero load latency in the common case. The reload it triggers is a normal navigation, so the app's existing beforeunload/unsaved-changes guard still protects in-progress edits.

Bump manifest version to 1.1.0 per the version-bump convention this change itself introduced.


Claude-Session: https://claude.ai/code/session_01Wtg7CtDQYPDfDnZZJBCzm7