### PR TITLE
Add hover tooltips (data-tip) and replace title attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,26 +23,26 @@
       <div id="modal-content" tabindex="0" class="color-dynamic-fade" data-color="">
         <div class="color-dynamic" id="file-content-header" data-color="">
 
-          <button id="save-btn" class="svg-wrapper-style" data-action="save-file-copy">
+          <button id="save-btn" class="svg-wrapper-style" data-action="save-file-copy" data-tip="save file">
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 50 50" width="59.2" height="58"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><defs><path id="h7a2b" d="M0 0c-1.9-0.1-7.1-0.9-11.3-0.6-4.2 0.3-10.9 0.2-13.8 2.5-2.9 2.3-3.6 5.9-3.8 11.2-0.1 5.3-2.6 17.1 3.1 20.8 5.7 3.7 25.1 4.6 31 1.5 5.9-3.1 3.8-15.7 4.3-20.1 0.5-4.4 0.2-4-1.4-6.5-1.6-2.6-6.8-7.3-8.1-8.8z"/><path id="k9f4e" d="M0 0c-0.4 0.2-1.7 0.2-2.3 1-0.7 0.8-1.6 2.5-1.6 3.9 0 1.4 0.6 3.3 1.6 4.3 1 1 2.7 1.3 4.2 1.4 1.5 0.1 3.6-0.1 4.8-0.6 1.3-0.6 2.3-1.8 2.7-2.9 0.4-1.1 0.2-2.6-0.3-3.7-0.4-1.1-2-2.3-2.4-2.7"/><path id="m2d1c" d="M0 0c-0.3 0.8-1.4 3.9-1.7 4.7"/><path id="p5s8q" d="M0 0c0.9 0.2 4.4 0.8 5.3 0.9"/></defs><g transform="translate(39.5 10.7)"><use href="#h7a2b" fill="none"/></g><g transform="translate(19.1 18)"><path d="M1.2 0h14.2c0.8 0 1.2 0.4 1.2 1.2v2.5c0 0.8-0.4 1.2-1.2 1.2H1.2C0.4 4.9 0 4.5 0 3.7V1.2C0 0.4 0.4 0 1.2 0z" stroke="none"/><path d="M1.2 0h14.2M15.4 0c0.8 0 1.2 0.4 1.2 1.2v2.5c0 0.8-0.4 1.2-1.2 1.2H1.2C0.4 4.9 0 4.5 0 3.7V1.2C0 0.4 0.4 0 1.2 0" fill="none"/></g><g id="save-disk-arrow"><g transform="translate(25.1 29.9)"><use href="#k9f4e" fill="none"/></g><g transform="translate(31.1 29.7)"><use href="#m2d1c" fill="none"/></g><g transform="translate(31.4 29.8)"><use href="#p5s8q" fill="none"/></g></g></g></svg>
 
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 50 50" width="117.2" height="116.3"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><g transform="translate(21.1,34.1)"><path id="h1" d="M0 0C1.2.9,4 6.4,7 5.4C10 4.4,16.1-4.1,17.9-6" fill="none"/><use href="#h1"/></g><g transform="translate(38.9,10.7)"><path id="h2" d="M0 0C-1.9-.1,-7.1-.9,-11.3-.6C-15.5-.3,-22.2-.4,-25.1 1.9C-28 4.1,-28.7 7.7,-28.8 13.1C-29 18.4,-29 29.9,-25.8 33.9C-22.5 37.9,-14.8 37.2,-9.2 37.3C-3.7 37.4,4.5 38.2,7.6 34.6C10.7 30.9,9.5 19.6,9.6 15.3C9.7 11,9.7 11.4,8.1 8.8C6.5 6.3,1.4 1.5,0 0" fill="none"/><use href="#h2"/></g><g transform="translate(18.5,18)"><path d="M1.2 0C5 0,8.9 0,15.4 0C16.2 0,16.6.4,16.6 1.2C16.6 1.8,16.6 2.4,16.6 3.7C16.6 4.5,16.2 4.9,15.4 4.9C11.3 4.9,7.3 4.9,1.2 4.9C0.4 4.9,0 4.5,0 3.7C0 2.9,0 2,0 1.2C0 .4,.4 0,1.2 0" stroke="none"/><path d="M1.2 0C6.4 0,11.5 0,15.4 0M1.2 0C5.1 0,9 0,15.4 0M15.4 0C16.2 0,16.6.4,16.6 1.2M15.4 0C16.2 0,16.6.4,16.6 1.2M16.6 1.2C16.6 2.2,16.6 3.1,16.6 3.7M16.6 1.2C16.6 1.8,16.6 2.4,16.6 3.7M16.6 3.7C16.6 4.5,16.2 4.9,15.4 4.9M16.6 3.7C16.6 4.5,16.2 4.9,15.4 4.9M15.4 4.9C9.8 4.9,4.1 4.9,1.2 4.9M15.4 4.9C10.6 4.9,5.8 4.9,1.2 4.9M1.2 4.9C0.4 4.9,0 4.5,0 3.7M1.2 4.9C0.4 4.9,0 4.5,0 3.7M0 3.7C0 2.8,0 1.8,0 1.2M0 3.7C0 3.2,0 2.7,0 1.2M0 1.2C0 .4,.4 0,1.2 0M0 1.2C0 .4,.4 0,1.2 0" fill="none"/></g></g></svg>
 
           </button>
 
-          <select id="file-content-history-select" data-action="history-select-change"></select>
+          <select id="file-content-history-select" data-action="history-select-change" data-tip="file version history"></select>
 
-          <button data-action="file-options-open" class="svg-wrapper-style" id="file-options-btn">
+          <button data-action="file-options-open" class="svg-wrapper-style" id="file-options-btn" data-tip="file options">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 82.2 79.5" width="82.2" height="79.5"><g stroke="currentColor" fill="currentColor" stroke-width="6" stroke-linecap="round"><defs><path id="h_x7a" d="M5.1 0h30.9m-30.9 0h30.9c3.4 0 5.1 1.7 5.1 5.1m-5.1-5.1c3.4 0 5.1 1.7 5.1 5.1m0 0c0 3.7 0 7.5 0 10.1m0-10.1c0 3.7 0 7.5 0 10.1m0 0c0 3.4-1.7 5.1-5.1 5.1m5.1-5.1c0 3.4-1.7 5.1-5.1 5.1m0 0H5.1m30.9 0H5.1c-3.4 0-5.1-1.7-5.1-5.1m5.1 5.1c-3.4 0-5.1-1.7-5.1-5.1m0 0V5.1m0 10.1V5.1C0 1.7 1.7 0 5.1 0m-5.1 5.1C0 1.7 1.7 0 5.1 0"/><path id="h_k9s" d="M0 0c-1 2.8-8.2 14.5-6.2 16.7 2 2.2 15.3-2.9 18.4-3.5"/><path id="h_m2v" d="M0 0C-4.2.8-21.1-3.3-25.4 4.9c-4.3 8.2-7.3 36.8-.2 44.4 7.2 7.6 35.3 4.3 43.2 1.2 7.9-3 3.5-16.2 4.2-19.5"/><path id="h_r4q" d="M0 0c.4.2 2.1.6 2.6 1.3.4.6.3 2.3.4 2.8"/></defs><use href="#h_x7a" transform="rotate(317.3 50.2 31.4) translate(29.6 21.2)" fill="none"/><use href="#h_k9s" transform="translate(28 39.5)" fill="none"/><use href="#h_m2v" transform="translate(39.8 15.5)" fill="none"/><use href="#h_r4q" transform="translate(22.1 52)"/></g></svg>
           </button>
 
-          <label class="svg-wrapper-style" id="minmax-label">
+          <label class="svg-wrapper-style" id="minmax-label" data-tip="toggle maximised view">
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 73.6 70.2" width="73.6" height="70.2"><g fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round"><defs><path id="a8f2b" d="M0 0c2.6 0.3 12.8-1.4 15.6 1.7 2.8 3 0.9 13.7 1.1 16.4"/></defs><use href="#a8f2b" x="46.4" y="10.2"/><use href="#a8f2b" x="10.2" y="42" transform="rotate(180 18.9 50.9)"/></g></svg>
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 71.2 67.1" width="71.2" height="67.1"><g stroke="currentColor" fill="currentColor" stroke-width="6" stroke-linecap="round"><defs><path id="a9f2" d="M0 0c2.6 0.3 12.8-1.4 15.6 1.7 2.8 3 0.9 13.7 1.1 16.4M0 0c2.6 0.3 12.8-1.4 15.6 1.7 2.8 3 0.9 13.7 1.1 16.4" fill="none"/><path id="b4d1" d="M0 0c0.3 2.7-1.3 13.5 1.7 16.5 2.9 3 13.3 1.2 15.9 1.4M0 0c0.3 2.7-1.3 13.5 1.7 16.5 2.9 3 13.3 1.2 15.9 1.4" fill="none"/><path id="c8e3" d="M0 0c-3.5 3.3-17.6 16.3-21.1 19.5M0 0c-3.5 3.3-17.6 16.3-21.1 19.5" fill="none"/><path id="d7a5" d="M0 0c3.2-3 16.2-15 19.4-18M0 0c3.2-3 16.2-15 19.4-18" fill="none"/></defs><use href="#a9f2" x="16.2" y="35.4"/><use href="#b4d1" x="39.3" y="11.4"/><use href="#c8e3" x="31.1" y="37.6"/><use href="#d7a5" x="41.8" y="28"/></g></svg>
             <input type="checkbox" name="modalmaxscreen" id="modalmaxscreen" data-action="toggle-modal-maxscreen">
 
           </label>
-          <button class="svg-wrapper-style" data-action="close-file-content-modal">
+          <button class="svg-wrapper-style" data-action="close-file-content-modal" data-tip="close">
             <svg id="close-svg" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66.3 64.5" width="66.3" height="64.5"><g fill="currentColor" stroke="currentColor" stroke-width="6" stroke-linecap="round"><defs><path id="a8f2" d="M0 0 C3.8 3.3 15.5 12.6 23 19.8 C30.4 27 41.1 39.2 44.7 43"/></defs><g transform="translate(10 10.4)"><use href="#a8f2"/></g><g transform="translate(10.8 54.5)"><path d="M0 0 C3.6 -3.9 13.9 -15.7 21.4 -23.1 C29 -30.6 41.5 -41 45.5 -44.5"/></g></g></svg>
           </button>
         </div>
@@ -54,13 +54,13 @@
 
         <div class="content-editable-controls">
           <div class="editor-btns">
-            <button data-action="editor-color-pick" class="svg-wrapper-style">
+            <button data-action="editor-color-pick" class="svg-wrapper-style" data-tip="pick colour">
               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 7 48 40" width="56.8" height="54.4"><g stroke="currentColor" fill="none" stroke-width="4" stroke-linecap="round"><defs><circle id="c_7af8" cx="1.9" cy="1.9" r="1"/></defs><use href="#c_7af8" x="20.2" y="18.7"/><use href="#c_7af8" x="16.5" y="27"/><use href="#c_7af8" x="29.1" y="16.2"/><use href="#c_7af8" x="35.6" y="22.5"/><g transform="translate(28.3 10)"><path d="M0 0C1.1.1 4.5.1 6.5.8c2 .7 3.6 1.2 5.6 3.3 2 2.1 5.5 6 6.2 9.4.7 3.4-.4 8.7-1.9 10.8-1.5 2.1-5 1.8-7 1.8-2 0-3.3-1.5-4.8-1.8-1.5-.3-3.5-.5-4.4 0-.9.5-1.2 2-.7 3.1.5 1.1 3.3 2.3 3.9 3.4.6 1.1 1.6 3-.3 3.4-1.9.3-8.1 0-11.3-1.3-3.2-1.3-6.1-4-7.8-6.5-1.7-2.5-2.3-5.3-2.3-8.3 0-3 1.2-7 2.3-9.4 1.1-2.4 2.7-3.6 4.5-4.9 1.8-1.3 4.3-2.5 6.2-3.1 1.9-.7 4.4-.6 5.3-.6M0 0C1.1.1 4.5.1 6.5.8c2 .7 3.6 1.2 5.6 3.3 2 2.1 5.5 6 6.2 9.4.7 3.4-.4 8.7-1.9 10.8-1.5 2.1-5 1.8-7 1.8-2 0-3.3-1.5-4.8-1.8-1.5-.3-3.5-.5-4.4 0-.9.5-1.2 2-.7 3.1.5 1.1 3.3 2.3 3.9 3.4.6 1.1 1.6 3-.3 3.4-1.9.3-8.1 0-11.3-1.3-3.2-1.3-6.1-4-7.8-6.5-1.7-2.5-2.3-5.3-2.3-8.3 0-3 1.2-7 2.3-9.4 1.1-2.4 2.7-3.6 4.5-4.9 1.8-1.3 4.3-2.5 6.2-3.1 1.9-.7 4.4-.6 5.3-.6"/></g></g></svg>
             </button>
-            <button data-action="editor-undo" class="svg-wrapper-style">
+            <button data-action="editor-undo" class="svg-wrapper-style" data-tip="undo">
               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 45 48" width="54.7" height="56"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><g transform="translate(17.7 45.6)"><path d="M0 0C3.8-0.3 18.6 2.1 22.6-1.9C26.6-6 29.3-20.4 24.2-24.4C19.2-28.4-2.4-25.7-7.7-26M0 0C3.8-0.3 18.6 2.1 22.6-1.9C26.6-6 29.3-20.4 24.2-24.4C19.2-28.4-2.4-25.7-7.7-26" fill="none"/></g><g transform="translate(10.1 20)"><path d="M0 0C0.9 1.1 4 4.8 5.3 6.6C6.5 8.3 7.1 10 7.5 10.7M0 0C0.9 1.1 4 4.8 5.3 6.6C6.5 8.3 7.1 10 7.5 10.7" fill="none"/></g><g transform="translate(10 19.5)"><path d="M0 0C1.5-1.6 7.6-7.9 9.1-9.5M0 0C1.5-1.6 7.6-7.9 9.1-9.5" fill="none"/></g></g></svg>
             </button>
-            <button data-action="editor-redo" class="svg-wrapper-style">
+            <button data-action="editor-redo" class="svg-wrapper-style" data-tip="redo">
               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 45 48" width="56.2" height="55"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><path d="M41.3 44.8C36.9 44.4 19.4 46.5 14.7 42.5C10 38.5 7.8 24.7 13 20.8C18.3 16.9 40.7 19.5 46.2 19.3" fill="none"/><path d="M46.1 19.6C45.3 20.6 42.5 23.8 41.1 25.7C39.7 27.6 38.2 30.1 37.6 31" fill="none"/><path d="M46.2 19.1C45.4 18.3 42.8 16 41.3 14.5C39.7 13 37.6 10.7 36.8 10" fill="none"/></g></svg>
             </button>
           </div>
@@ -69,7 +69,7 @@
             <div class="flex-row label_group_text_toggle">
               <div>html</div>
               <label for="render_toggle" class="switch"><input type="checkbox" id="render_toggle" name="render_toggle"
-                  data-action="toggle-render-text"><span class="slider"></span></label>
+                  data-action="toggle-render-text" data-tip="switch between rendered and plain text"><span class="slider"></span></label>
               <div>txt</div>
             </div>
         </div>
@@ -80,7 +80,7 @@
 
   <div class="flex-row">
     <div>
-      <button title="choose your folder" id="btn_loadDirectoryHandles" data-click-loadfolder>
+      <button data-tip="choose your folder" id="btn_loadDirectoryHandles" data-click-loadfolder>
         <div class="svg-wrapper-style">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 53.3 51.6" width="53.3" height="51.6"><g stroke="#1e1e1e" fill="none" stroke-width="4" stroke-linecap="round"><g id="load-folder-arrow"><g transform="translate(30.2 23.3) rotate(7.9 -2.8 5.3)"><path d="M0 0c.4.2 1.7.2 2.3 1 .7.9 1.6 2.6 1.6 3.9 0 1.4-.6 3.3-1.5 4.3-1 1-2.7 1.4-4.2 1.5-1.5.2-3.6 0-4.8-.6-1.3-.6-2.3-1.7-2.7-2.8-.4-1.1-.2-2.6.3-3.7.4-1 1.9-2.3 2.3-2.7"/></g><g transform="translate(24.6 22.8) rotate(7.9 .9 2.4)"><path d="M0 0c.3.8 1.4 3.9 1.7 4.7"/></g><g transform="translate(24.5 22.4) rotate(7.9 -2.7 .5)"><path d="M0 0c-.9.2-4.4.8-5.3.9"/></g></g><g transform="translate(10 10.4)"><path d="M0 0c.3 4.6-1.1 22.7 1.9 27.8 3 5.1 11.2 3 16.1 2.9 4.9-.1 11.1.7 13.4-3.3 2.3-4 2.7-17.1.2-20.6-2.5-3.6-11.9.2-15.3-.9-3.4-1.1-2.2-4.9-4.9-5.9C11.4-1 4.6 0 0 0"/></g></g></svg>
         </div>
@@ -95,7 +95,7 @@
       <input type="checkbox" name="fullscreen" id="fullscreen" data-action="toggle-fullscreen">
     </label> -->
 
-    <button title="open settings" data-action="open-settings-modal" class="svg-wrapper-style">
+    <button data-tip="open settings" data-action="open-settings-modal" class="svg-wrapper-style">
       <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="7 5 10 40" width="50" height="50"><g stroke="currentColor" fill="none" stroke-width="4" stroke-linecap="round"><defs><path id="k9x2p" d="M3.4 1.92 C3.4 2.04,3.4 2.15,3.38 2.26 C3.36 2.37,3.34 2.48,3.3 2.58 C3.27 2.69,3.23 2.79,3.18 2.89 C3.13 2.98,3.07 3.08,3.01 3.16 C2.94 3.25,2.87 3.33,2.8 3.4 C2.72 3.47,2.64 3.53,2.55 3.59 C2.47 3.65,2.38 3.69,2.28 3.73 C2.19 3.77,2.09 3.8,2 3.82 C1.9 3.84,1.8 3.85,1.7 3.85 C1.6 3.85,1.5 3.84,1.41 3.82 C1.31 3.8,1.21 3.77,1.12 3.73 C1.03 3.69,0.94 3.65,0.85 3.59 C0.77 3.53,0.68 3.47,0.61 3.4 C0.53 3.33,0.46 3.25,0.4 3.16 C0.33 3.08,0.28 2.98,0.23 2.89 C0.18 2.79,0.14 2.69,0.1 2.58 C0.07 2.48,0.04 2.37,0.03 2.26 C0.01 2.15,0 2.04,0 1.92 C0 1.81,0.01 1.7,0.03 1.59 C0.04 1.48,0.07 1.37,0.1 1.27 C0.14 1.16,0.18 1.06,0.23 0.96 C0.28 0.87,0.33 0.77,0.4 0.69 C0.46 0.6,0.53 0.52,0.61 0.45 C0.68 0.38,0.77 0.31,0.85 0.26 C0.94 0.2,1.03 0.15,1.12 0.12 C1.21 0.08,1.31 0.05,1.41 0.03 C1.5 0.01,1.6 0,1.7 0 C1.8 0,1.9 0.01,2 0.03 C2.09 0.05,2.19 0.08,2.28 0.12 C2.38 0.15,2.47 0.2,2.55 0.26 C2.64 0.31,2.72 0.38,2.8 0.45 C2.87 0.52,2.94 0.6,3.01 0.69 C3.07 0.77,3.13 0.87,3.18 0.96 C3.23 1.06,3.27 1.16,3.3 1.27 C3.34 1.37,3.36 1.48,3.38 1.59 C3.4 1.7,3.4 1.87,3.4 1.92 C3.41 1.98,3.41 1.87,3.4 1.92"/></defs><use href="#k9x2p" transform="translate(10.07 10)"/><use href="#k9x2p" transform="translate(10.32 22.28) rotate(51.8 1.7 1.92)"/><use href="#k9x2p" transform="translate(10.13 34.66) rotate(312.17 1.7 1.92)"/></g></svg>
     </button>
   </div>
@@ -106,8 +106,8 @@
 
         <div class="flex-row justify-content-center">
 
-          <label title="click to toggle file content search on and off" class="svg-wrapper-style" id="content-search-label">
-            <svg title="content search off - click to search inside files" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="-5 0 230 120" width="100"height="50"><defs><style class="style-fonts"></style></defs><g stroke="black" stroke-width="24" fill="none" stroke-linecap="round"><g transform="translate(18.67 10) rotate(0 95.33 24.99)"><path d="M0 0 C6 5.82, 20.67 26.61, 36 34.94 C51.33 43.26, 73.78 49.74, 92 49.97 C110.22 50.21, 128.89 44.22, 145.33 36.36 C161.78 28.51, 183.11 8.44, 190.67 2.85 M0 0 C6 5.82, 20.67 26.61, 36 34.94 C51.33 43.26, 73.78 49.74, 92 49.97 C110.22 50.21, 128.89 44.22, 145.33 36.36 C161.78 28.51, 183.11 8.44, 190.67 2.85"></path></g><g transform="translate(110 60) rotate(0 0.33 15.67)"><path d="M0 0 C0.11 5.22, 0.56 26.11, 0.67 31.33 M0 0 C0.11 5.22, 0.56 26.11, 0.67 31.33"></path></g><g transform="translate(186.67 32) rotate(0 9.67 10.67)"><path d="M0 0 C3.22 3.56, 16.11 17.78, 19.33 21.33 M0 0 C3.22 3.56, 16.11 17.78, 19.33 21.33"></path></g><g transform="translate(152 50) rotate(0 7.33 12)"><path d="M0 0 C2.44 4, 12.22 20, 14.67 24 M0 0 C2.44 4, 12.22 20, 14.67 24"></path></g><g transform="translate(34 30.67) rotate(0 -12 10.33)"><path d="M0 0 C-4 3.44, -20 17.22, -24 20.67 M0 0 C-4 3.44, -20 17.22, -24 20.67"></path></g><g transform="translate(73.33 51.33) rotate(0 -8 13.67)"><path d="M0 0 C-2.67 4.56, -13.33 22.78, -16 27.33 M0 0 C-2.67 4.56, -13.33 22.78, -16 27.33"></path></g></g></svg>
+          <label data-tip="toggle content search" class="svg-wrapper-style" id="content-search-label">
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="-5 0 230 120" width="100"height="50"><defs><style class="style-fonts"></style></defs><g stroke="black" stroke-width="24" fill="none" stroke-linecap="round"><g transform="translate(18.67 10) rotate(0 95.33 24.99)"><path d="M0 0 C6 5.82, 20.67 26.61, 36 34.94 C51.33 43.26, 73.78 49.74, 92 49.97 C110.22 50.21, 128.89 44.22, 145.33 36.36 C161.78 28.51, 183.11 8.44, 190.67 2.85 M0 0 C6 5.82, 20.67 26.61, 36 34.94 C51.33 43.26, 73.78 49.74, 92 49.97 C110.22 50.21, 128.89 44.22, 145.33 36.36 C161.78 28.51, 183.11 8.44, 190.67 2.85"></path></g><g transform="translate(110 60) rotate(0 0.33 15.67)"><path d="M0 0 C0.11 5.22, 0.56 26.11, 0.67 31.33 M0 0 C0.11 5.22, 0.56 26.11, 0.67 31.33"></path></g><g transform="translate(186.67 32) rotate(0 9.67 10.67)"><path d="M0 0 C3.22 3.56, 16.11 17.78, 19.33 21.33 M0 0 C3.22 3.56, 16.11 17.78, 19.33 21.33"></path></g><g transform="translate(152 50) rotate(0 7.33 12)"><path d="M0 0 C2.44 4, 12.22 20, 14.67 24 M0 0 C2.44 4, 12.22 20, 14.67 24"></path></g><g transform="translate(34 30.67) rotate(0 -12 10.33)"><path d="M0 0 C-4 3.44, -20 17.22, -24 20.67 M0 0 C-4 3.44, -20 17.22, -24 20.67"></path></g><g transform="translate(73.33 51.33) rotate(0 -8 13.67)"><path d="M0 0 C-2.67 4.56, -13.33 22.78, -16 27.33 M0 0 C-2.67 4.56, -13.33 22.78, -16 27.33"></path></g></g></svg>
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg"viewBox="-10 0 230 120" width="100" height="50"><defs><style class="style-fonts"></style></defs><g stroke="black" stroke-width="16" fill="none" stroke-linecap="round"><g transform="translate(11 58.99)"><path d="M0 0 C6 5.82, 20.67 26.61, 36 34.94 C51.33 43.26, 73.78 49.74, 92 49.97 C110.22 50.21, 128.89 44.22, 145.33 36.36 C161.78 28.51, 183.11 8.44, 190.67 2.85"></path></g><g transform="translate(200.67 59.98)"><path d="M0 0 C-6 -5.82, -20.67 -26.61, -36 -34.94 C-51.33 -43.26, -73.78 -49.74, -92 -49.97 C-110.22 -50.21, -128.89 -44.22, -145.33 -36.36 C-161.78 -28.51, -183.11 -8.44, -190.67 -2.85"></path></g><g transform="translate(53.33 23.99)"><path d="M0 0 C-1.89 4.22, -9.44 16.78, -11.33 25.33 C-13.22 33.89, -13.33 43.22, -11.33 51.33 C-9.33 59.44, -1.33 70.22, 0.67 74"></path></g><g transform="translate(152.27 21.66)"><path d="M0 0 C1.89 4.22, 9.44 16.78, 11.33 25.33 C13.22 33.89, 13.33 43.22, 11.33 51.33 C9.33 59.44, 1.33 70.22, -0.67 74"></path></g><g transform="translate(83.67 37.32)"><circle cx="22.67" cy="22.67" r="22.67" fill="black" stroke="none"></circle></g></g></svg>
             <input type="checkbox" name="contentsearch" id="contentsearch" data-action="toggle-content-search">
 
@@ -115,9 +115,9 @@
 
           <div class="searchbox-container flexgrow">
             <input data-action="search-files" type="text" id="searchbox" name="searchbox" size="10"
-            minlength="3" maxlength="100" placeholder='' autocomplete="off" enterkeyhint="search"/>
+            minlength="3" maxlength="100" placeholder='' autocomplete="off" enterkeyhint="search" data-tip="search files"/>
 
-            <button title="search tags"class="searchbox-tag-btn" data-action="start-tag-search">#</button>
+            <button data-tip="search tags" class="searchbox-tag-btn" data-action="start-tag-search">#</button>
           </div>
 
         </div>
@@ -128,16 +128,16 @@
 
           <div class="ANDOR_label">OR</div>
           <label for="and_filter" class="switch"><input type="checkbox" id="and_filter" name="and_filter"
-              data-action="toggle-filter-mode"><span class="slider"></span></label>
+              data-action="toggle-filter-mode" data-tip="toggle AND / OR matching"><span class="slider"></span></label>
           <div class="ANDOR_label">AND</div>
 
         </div>
 
-        <label for="toggle-search-highlights" class="svg-wrapper-style filter-options-position filters-options-style" id="search-highlights-toggle-label">
+        <label for="toggle-search-highlights" class="svg-wrapper-style filter-options-position filters-options-style" id="search-highlights-toggle-label" data-tip="toggle search highlights">
           <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 45 40" width="54.3" height="51.6"><g stroke="#1e1e1e" fill="none" stroke-width="4" stroke-linecap="round"><g transform="translate(20.4,24.8)"><path d="M0 0C1.3-1.4 4.8-5.8 7.5-8.3C10.2-10.7 13.7-14.8 16.3-14.8C19-14.7 23.4-10.6 23.3-8.1C23.3-5.6 18.8-2.1 16.2.4C13.6 2.9 9.1 6 7.7 7.1"/></g><g transform="translate(21.9,25.2)"><path  id="highlight-nib" d="M0 0C-.6.8-3.9 3-3.8 4.6C-3.7 6.1-.9 9.1.6 9.3C2.1 9.5 5.3 7.3 5.2 5.8C5.1 4.2.9 1 0 0" fill="yellow" stroke="none"/><path d="M0 0C-.6.8-3.9 3-3.8 4.6C-3.7 6.1-.9 9.1.6 9.3C2.1 9.5 5.3 7.3 5.2 5.8C5.1 4.2.9 1 0 0"/></g><g transform="translate(10.8,37.3)"><path  id="highlight-line" d="M0 0C2.9.1 12.1.6 17.5.7C22.9.7 30 .4 32.5.3" stroke="yellow"/></g><g transform="translate(10,41.3)"><path d="M0 0C3 0 12.5.2 18.2.3C23.9.3 31.6.1 34.3.1"/></g></g></svg>
           <input type="checkbox" id="toggle-search-highlights" name="toggle-search-highlights" checked>
         </label>
-        <button id="clear-filters-btn" class="filter-options-position filters-options-style svg-wrapper-style" data-action="clear-all-filters">
+        <button id="clear-filters-btn" class="filter-options-position filters-options-style svg-wrapper-style" data-action="clear-all-filters" data-tip="clear all filters">
           <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="3 3 48 48" width="52.6" height="54.6"><g stroke="currentColor" fill="none" stroke-width="4" stroke-linecap="round"><g transform="translate(14.8 13.2)"><path d="M0 0C0 4.5-1.8 21.9 0 27.1C1.8 32.3 7.3 31.1 11 31.2C14.8 31.2 20.6 32.7 22.5 27.5C24.5 22.4 22.7 4.6 22.8 0M0 0C0 4.5-1.8 21.9 0 27.1C1.8 32.3 7.3 31.1 11 31.2C14.8 31.2 20.6 32.7 22.5 27.5C24.5 22.4 22.7 4.6 22.8 0"/></g><g transform="translate(42.6 13.3)"><path d="M0 0C-2.7-0.1-10.8-0.7-16.2-0.6C-21.7-0.6-29.9 0.2-32.7 0.4M0 0C-2.7-0.1-10.8-0.7-16.2-0.6C-21.7-0.6-29.9 0.2-32.7 0.4"/></g><g transform="translate(22.1 20.1)"><path d="M0 0C0 1-0 3.6 0 6.2C0 8.7 0.2 13.9 0.2 15.4M0 0C0 1-0 3.6 0 6.2C0 8.7 0.2 13.9 0.2 15.4"/></g><g transform="translate(30.1 20.5)"><path d="M0 0C0 1.3 0.2 5.1 0.2 7.6C0.2 10.1-0.1 13.6-0.2 14.8M0 0C0 1.3 0.2 5.1 0.2 7.6C0.2 10.1-0.1 13.6-0.2 14.8"/></g><g transform="translate(30.3 10)"><path d="M0 0C-1.5 0-7.5 0.2-9 0.2M0 0C-1.5 0-7.5 0.2-9 0.2"/></g></g></svg>
         </button>
 
@@ -151,25 +151,25 @@
       <div class="file-display-controls-top">
         <div class="view-controls">
           <label for="view-select">
-            <select id="view-select" data-action="view-select"></select>
+            <select id="view-select" data-action="view-select" data-tip="change view"></select>
           </label>
         </div>
         <div class="flexgrow"></div>
-        <button class="svg-wrapper-style" data-action="toggle-file-controls" title="controls">
+        <button class="svg-wrapper-style" data-action="toggle-file-controls" data-tip="controls">
           <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="2 5 47 33" width="106" height="85"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><path d="M10.5 13.1c.9 0 4.6.1 5.5.1M38.5 29.1c.7 0 3.7 0 4.4 0M24.6 13.2c1.2-.1 4.2-.5 7.3-.5 3 0 9.2.4 11.1.4M10 29.6c1.7.1 6.7.6 10.2.6 3.4-.1 8.8-.5 10.5-.6M22.6 16.3c0-1.1-.1-5.3-.2-6.3M37.4 32.5c0-1.1-.1-5.5-.1-6.7" fill="none"/></g></svg>
         </button>
       </div>
 
       <div class="file-display-controls-panel" id="file-display-controls-panel">
         <div class="file-display-controls-panel-inner">
-          <button title="show all tags" class="tag-taxonomy-btn" data-action="render-tag-taxonomy">show tags</button>
+          <button data-tip="show all tags" class="tag-taxonomy-btn" data-action="render-tag-taxonomy">show tags</button>
           <div class="sort-controls">
             sort:
             <label for="sort-select">
-              <select id="sort-select" data-action="sort-select"></select>
+              <select id="sort-select" data-action="sort-select" data-tip="change sort order"></select>
             </label>
             <label class="sort-direction-label" for="sort-direction">
-              <input type="checkbox" id="sort-direction" data-action="sort-direction-toggle">
+              <input type="checkbox" id="sort-direction" data-action="sort-direction-toggle" data-tip="reverse sort direction">
             </label>
           </div>
         </div>
@@ -184,7 +184,7 @@
   </main>
 
   <dialog id="modal-settings" closedby="any">
-    <button class="modal-close-btn" data-action="close-settings-modal">✕</button>
+    <button class="modal-close-btn" data-action="close-settings-modal" data-tip="close settings">✕</button>
 
     <h2 class="menu-title">Menu</h2>
 
@@ -193,28 +193,28 @@
     <div class="settings-row">
       <span class="settings-label">Colour theme</span>
       <div class="color-select-radio">
-        <label class="formcontrol"><input type="radio" name="radio" id="blackandwhite" checked />b&w</label>
-        <label class="formcontrol"><input type="radio" name="radio" id="snow"/>snow</label>
-        <label class="formcontrol"><input type="radio" name="radio" id="glow" />glow</label>
+        <label class="formcontrol"><input type="radio" name="radio" id="blackandwhite" checked data-tip="black and white theme" />b&w</label>
+        <label class="formcontrol"><input type="radio" name="radio" id="snow" data-tip="snow theme"/>snow</label>
+        <label class="formcontrol"><input type="radio" name="radio" id="glow" data-tip="glow theme" />glow</label>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Pagination size</span>
       <div class="settings-control-group">
-        <input id="pagination-size-input" type="number" min="10" max="1000" step="1" data-action="pagination-size-change">
-        <button class="settings-reset-btn" data-action="reset-pagination-size">↺</button>
+        <input id="pagination-size-input" type="number" min="10" max="1000" step="1" data-action="pagination-size-change" data-tip="files per page">
+        <button class="settings-reset-btn" data-action="reset-pagination-size" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Animate file filtering</span>
-      <label class="switch"><input type="checkbox" id="file-transitions-enabled" checked><span class="slider"></span></label>
+      <label class="switch"><input type="checkbox" id="file-transitions-enabled" checked data-tip="toggle filtering animations"><span class="slider"></span></label>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Show user file colours</span>
-      <label class="switch"><input type="checkbox" id="show-user-file-colours" checked><span class="slider"></span></label>
+      <label class="switch"><input type="checkbox" id="show-user-file-colours" checked data-tip="toggle file colours"><span class="slider"></span></label>
     </div>
 
     <h4>Interface</h4>
@@ -222,39 +222,39 @@
     <div class="settings-row">
       <span class="settings-label">Text size adjust</span>
       <div class="settings-control-group">
-        <label class="formcontrol"><input type="radio" name="font-size-app" value="0.8" data-action="font-size-app-change">S</label>
-        <label class="formcontrol"><input type="radio" name="font-size-app" value="1" checked data-action="font-size-app-change">M</label>
-        <label class="formcontrol"><input type="radio" name="font-size-app" value="1.2" data-action="font-size-app-change">L</label>
-        <button class="settings-reset-btn" data-action="reset-font-size-app">↺</button>
+        <label class="formcontrol"><input type="radio" name="font-size-app" value="0.8" data-action="font-size-app-change" data-tip="small text">S</label>
+        <label class="formcontrol"><input type="radio" name="font-size-app" value="1" checked data-action="font-size-app-change" data-tip="medium text">M</label>
+        <label class="formcontrol"><input type="radio" name="font-size-app" value="1.2" data-action="font-size-app-change" data-tip="large text">L</label>
+        <button class="settings-reset-btn" data-action="reset-font-size-app" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Font (labels)</span>
       <div class="settings-control-group">
-        <select data-action="font-style-app-label-change">
+        <select data-action="font-style-app-label-change" data-tip="label font">
           <option value="Arial, Helvetica, sans-serif">Arial</option>
         </select>
-        <button class="settings-reset-btn" data-action="reset-font-style-app-label">↺</button>
+        <button class="settings-reset-btn" data-action="reset-font-style-app-label" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Font (inputs)</span>
       <div class="settings-control-group">
-        <select data-action="font-style-app-input-change">
+        <select data-action="font-style-app-input-change" data-tip="input font">
           <option value="Consolas">Consolas</option>
         </select>
-        <button class="settings-reset-btn" data-action="reset-font-style-app-input">↺</button>
+        <button class="settings-reset-btn" data-action="reset-font-style-app-input" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Button size</span>
       <div class="settings-control-group">
-        <label><input type="radio" name="button-size" data-action="button-size-change" value="1" checked> M</label>
-        <label><input type="radio" name="button-size" data-action="button-size-change" value="1.2"> L</label>
-        <button class="settings-reset-btn" data-action="reset-button-size">↺</button>
+        <label><input type="radio" name="button-size" data-action="button-size-change" value="1" checked data-tip="medium buttons"> M</label>
+        <label><input type="radio" name="button-size" data-action="button-size-change" value="1.2" data-tip="large buttons"> L</label>
+        <button class="settings-reset-btn" data-action="reset-button-size" data-tip="reset to default">↺</button>
       </div>
     </div>
 
@@ -263,40 +263,40 @@
     <div class="settings-row">
       <span class="settings-label">Text size adjust</span>
       <div class="settings-control-group">
-        <label class="formcontrol"><input type="radio" name="font-size-file" value="0.8" data-action="font-size-file-change">S</label>
-        <label class="formcontrol"><input type="radio" name="font-size-file" value="1" checked data-action="font-size-file-change">M</label>
-        <label class="formcontrol"><input type="radio" name="font-size-file" value="1.4" data-action="font-size-file-change">L</label>
-        <button class="settings-reset-btn" data-action="reset-font-size-file">↺</button>
+        <label class="formcontrol"><input type="radio" name="font-size-file" value="0.8" data-action="font-size-file-change" data-tip="small text">S</label>
+        <label class="formcontrol"><input type="radio" name="font-size-file" value="1" checked data-action="font-size-file-change" data-tip="medium text">M</label>
+        <label class="formcontrol"><input type="radio" name="font-size-file" value="1.4" data-action="font-size-file-change" data-tip="large text">L</label>
+        <button class="settings-reset-btn" data-action="reset-font-size-file" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Font (html)</span>
       <div class="settings-control-group">
-        <select data-action="font-style-html-change">
+        <select data-action="font-style-html-change" data-tip="html font">
           <option value="Arial, Helvetica, sans-serif">Arial</option>
         </select>
-        <button class="settings-reset-btn" data-action="reset-font-style-html">↺</button>
+        <button class="settings-reset-btn" data-action="reset-font-style-html" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Font (text)</span>
       <div class="settings-control-group">
-        <select data-action="font-style-text-change">
+        <select data-action="font-style-text-change" data-tip="plain text font">
           <option value="Consolas">Consolas</option>
         </select>
-        <button class="settings-reset-btn" data-action="reset-font-style-text">↺</button>
+        <button class="settings-reset-btn" data-action="reset-font-style-text" data-tip="reset to default">↺</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Font (headers)</span>
       <div class="settings-control-group">
-        <select data-action="font-style-headers-change">
+        <select data-action="font-style-headers-change" data-tip="headers font">
           <option value="Trebuchet MS, Arial, Helvetica, sans-serif">Trebuchet MS</option>
         </select>
-        <button class="settings-reset-btn" data-action="reset-font-style-headers">↺</button>
+        <button class="settings-reset-btn" data-action="reset-font-style-headers" data-tip="reset to default">↺</button>
       </div>
     </div>
 
@@ -305,16 +305,16 @@
     <div class="settings-row">
       <span class="settings-label">Backup</span>
       <div class="settings-backup-btns">
-        <button class="btn-base-style" data-action="backup-content">Content only</button>
-        <button class="btn-base-style" data-action="backup-full">Full backup</button>
+        <button class="btn-base-style" data-action="backup-content" data-tip="back up file contents only">Content only</button>
+        <button class="btn-base-style" data-action="backup-full" data-tip="back up everything">Full backup</button>
       </div>
     </div>
 
     <div class="settings-row">
       <span class="settings-label">Restore</span>
       <div class="settings-backup-btns">
-        <button class="btn-base-style" id="btn-import-opfs" data-click-importtartoopfs>Import backup</button>
-        <button class="btn-base-style" id="btn-load-opfs" data-click-loadopfs disabled>Open OPFS</button>
+        <button class="btn-base-style" id="btn-import-opfs" data-click-importtartoopfs data-tip="import a backup">Import backup</button>
+        <button class="btn-base-style" id="btn-load-opfs" data-click-loadopfs disabled data-tip="open saved backup">Open OPFS</button>
       </div>
     </div>
 
@@ -353,32 +353,32 @@
   <dialog id="modal-unsaved-warning">
     <p id="modal-unsaved-warning-text"></p>
     <div class="unsaved-warning-buttons">
-      <button id="modal-unsaved-warning-proceed" class="unsaved-warning-button-discard" data-action="warning-proceed"></button>
-      <button id="modal-unsaved-warning-cancel" class="unsaved-warning-button-keep" data-action="warning-cancel"></button>
+      <button id="modal-unsaved-warning-proceed" class="unsaved-warning-button-discard" data-action="warning-proceed" data-tip="discard changes"></button>
+      <button id="modal-unsaved-warning-cancel" class="unsaved-warning-button-keep" data-action="warning-cancel" data-tip="keep editing"></button>
     </div>
   </dialog>
 
   <dialog id="modal-file-options" closedby="any">
-    <button class="modal-close-btn" data-action="file-options-cancel">✕</button>
+    <button class="modal-close-btn" data-action="file-options-cancel" data-tip="close">✕</button>
     <h2>File options</h2>
     <form class="file-options-form">
       <div class="file-options-field">
         <label for="file-options-folder-input">Change folder:</label>
         <div class="file-options-field-row">
           <input id="file-options-folder-input" type="text" list="gypsum-folders" autocomplete="off" placeholder="(root)">
-          <button type="button" data-action="file-options-move-confirm">move</button>
+          <button type="button" data-action="file-options-move-confirm" data-tip="move file">move</button>
         </div>
       </div>
       <div class="file-options-field">
         <label for="rename-name-input">Change filename:</label>
         <div class="file-options-field-row">
           <input id="rename-name-input" type="text" autocomplete="off">
-          <button type="button" data-action="rename-confirm">rename</button>
+          <button type="button" data-action="rename-confirm" data-tip="rename file">rename</button>
         </div>
       </div>
       <p id="file-options-error-slot" class="file-options-error"></p>
       <div class="flex-column">
-        <button type="button" class="file-options-button-delete" data-action="delete-file">delete file</button>
+        <button type="button" class="file-options-button-delete" data-action="delete-file" data-tip="delete file">delete file</button>
       </div>
     </form>
     <datalist id="gypsum-folders"></datalist>
@@ -387,13 +387,15 @@
   <dialog id="modal-color-picker" data-action="close-color-picker-outside">
     <div id="color-picker-header">
       <button id="color-picker-expand-btn" class="color-picker-expand-btn"
-              data-action="color-picker-expand" title="Show more colours"
+              data-action="color-picker-expand" data-tip="show more colours"
               aria-expanded="false"></button>
     </div>
     <div id="color-picker-content"></div>
   </dialog>
 
-  <button id="btn-new-note" data-action="create-new-note" disabled>+</button>
+  <button id="btn-new-note" data-action="create-new-note" disabled data-tip="new note">+</button>
+
+  <div id="tooltip" aria-hidden="true"></div>
 
 </body>
 <script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/public/css/tooltip.css
+++ b/public/css/tooltip.css
@@ -1,0 +1,61 @@
+#tooltip {
+    position: fixed;
+    position-anchor: --tooltip-anchor;
+    top: anchor(bottom);
+    left: anchor(left);
+    margin-top: 6px;
+    position-try-fallbacks: --tooltip-flip-up, --tooltip-flip-right, --tooltip-flip-up-right;
+
+    z-index: 1000;
+    pointer-events: none;
+
+    background-color: var(--colour-contr);
+    color: var(--colour-neutral);
+    font-size: 0.78rem;
+    line-height: 1.2;
+    padding: 4px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    max-width: 240px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+
+    display: none;
+    opacity: 0;
+    transform: scale(0.92);
+    transition: opacity 0.12s ease, transform 0.12s ease,
+                display 0.12s allow-discrete, overlay 0.12s allow-discrete;
+}
+
+#tooltip.visible {
+    display: block;
+    opacity: 1;
+    transform: scale(1);
+}
+
+@starting-style {
+    #tooltip.visible {
+        opacity: 0;
+        transform: scale(0.92);
+    }
+}
+
+@position-try --tooltip-flip-up {
+    top: auto;
+    bottom: anchor(top);
+    margin-top: 0;
+    margin-bottom: 6px;
+}
+
+@position-try --tooltip-flip-right {
+    left: auto;
+    right: anchor(right);
+}
+
+@position-try --tooltip-flip-up-right {
+    top: auto;
+    bottom: anchor(top);
+    left: auto;
+    right: anchor(right);
+    margin-top: 0;
+    margin-bottom: 6px;
+}

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -45,6 +45,7 @@ import { handleToggleFileControls } from './ui-functions-click/handle-toggle-fil
 import { handlePaginationSizeChange, handleResetPaginationSize } from './ui-functions-click/pagination-size-settings.js';
 import { handleSearchboxAutocomplete, handleAutocompleteKeydown, handleAutocompleteClickOutside, initTagAutocomplete } from '../autocomplete/tag-autocomplete.js';
 import { handleTableColHover } from './ui-functions-table/table-col-hover.js';
+import { initTooltip } from './tooltip.js';
 
 /**
  * Adds event listeners to the document for click, change, and keyup events.
@@ -52,6 +53,7 @@ import { handleTableColHover } from './ui-functions-table/table-col-hover.js';
  */
 export function addActionHandlers() {
     initTagAutocomplete();
+    initTooltip();
     document.addEventListener("click", clickDelegate);
     document.addEventListener("change", changeDelegate);
     document.addEventListener("keydown", keyDownDelegate);

--- a/public/js/ui/pagination/render-pagination.js
+++ b/public/js/ui/pagination/render-pagination.js
@@ -48,7 +48,7 @@ export function renderPagination(totalVisible) {
         } else if (item === c) {
             html += `<span class="pagination-elem-style pagination-current">${item}</span>`;
         } else {
-            html += `<button class="pagination-elem-style pagination-btn" data-action="change-page" data-page="${item}">${item}</button>`;
+            html += `<button class="pagination-elem-style pagination-btn" data-action="change-page" data-page="${item}" data-tip="go to page ${item}">${item}</button>`;
         }
     }
 

--- a/public/js/ui/render-file-list-grid.js
+++ b/public/js/ui/render-file-list-grid.js
@@ -37,7 +37,7 @@ export function renderFileList_grid(renderEverything) {
   //      const tag_list = file.tags.join(" ");
         const filename_html = renderFilename(file.filepath);
         file_html += `
-        <div class="note-grid keyboard-navigable color-dynamic" tabindex="0" data-index="${index}" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}">
+        <div class="note-grid keyboard-navigable color-dynamic" tabindex="0" data-index="${index}" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}" data-tip="open file">
 
             <div data-prop="filename">${filename_html}</div>
 

--- a/public/js/ui/render-file-list-list.js
+++ b/public/js/ui/render-file-list-list.js
@@ -36,7 +36,7 @@ export function renderFileList_list(renderEverything) {
                     <details>
                         <summary><span data-prop="filename">${filename_html}</span> ${tag_pills_html}</summary>
                         <ul>
-                        <li><span class="show-content-tag color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal">open</span></li>
+                        <li><span class="show-content-tag color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-tip="open file">open</span></li>
                         `;
             for (const key in file) {
                 const value = file[key];

--- a/public/js/ui/render-file-list-peek.js
+++ b/public/js/ui/render-file-list-peek.js
@@ -31,7 +31,7 @@ export function renderFileList_peek(renderEverything) {
                 .replace(/\n/g, '<br>');
 
             file_html += `
-        <div class="note-grid keyboard-navigable color-dynamic" tabindex="0" data-index="${index}" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}">
+        <div class="note-grid keyboard-navigable color-dynamic" tabindex="0" data-index="${index}" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}" data-tip="open file">
 
             <h3 class="color-dynamic" data-color="${file.color}" data-prop="title">${file.title}</h3>
 

--- a/public/js/ui/render-file-list-search.js
+++ b/public/js/ui/render-file-list-search.js
@@ -26,7 +26,7 @@ export function renderFileList_search(renderEverything) {
             }
 
             file_html += `
-                <div class="search-view-item color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}">
+                <div class="search-view-item color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}" data-tip="open file">
 
                     <div class="search-view-fileinfo">
                         <div class="note-search" data-color="${file.color}">

--- a/public/js/ui/render-tag-taxonmy.js
+++ b/public/js/ui/render-tag-taxonmy.js
@@ -20,7 +20,7 @@ export function renderTagTaxonomy() {
 
     let taxon_html = `<div class="border-top-straight border-bottom-straight margin-bottom padding-top">
         <div id="tag_output">
-            <div class="tag-taxon-hide-btn" data-action="hide-tag-taxonomy"># hide tags</div>`;
+            <div class="tag-taxon-hide-btn" data-action="hide-tag-taxonomy" data-tip="hide tags"># hide tags</div>`;
 
     for (const [parentName, childMap] of appState.myParentMap) {
 

--- a/public/js/ui/tooltip.js
+++ b/public/js/ui/tooltip.js
@@ -1,0 +1,109 @@
+/**
+ * @file Global hover tooltip. The single reused #tooltip element (declared in
+ * index.html) is shown, hidden, and repositioned via CSS anchor positioning,
+ * mirroring the technique used by the tag-autocomplete popup
+ * (autocomplete/tag-autocomplete.js, autocomplete/tag-popup.js).
+ */
+
+const SHOW_DELAY_MS = 500;
+const TOOLTIP_ANCHOR_NAME = '--tooltip-anchor';
+
+let _tooltipEl = null;   // the single reused element, looked up from index.html
+let _currentEl = null;   // element currently tracked as hovered (pending or shown)
+let _anchoredEl = null;  // element that currently holds anchor-name (only one at a time)
+let _showTimer = null;
+let _visible = false;
+
+/**
+ * Wires up document-level hover delegation for any element carrying `data-tip`.
+ * Idempotent: addActionHandlers() may run more than once per page load.
+ * @returns {void}
+ */
+export function initTooltip() {
+    if (_tooltipEl) return;
+    _tooltipEl = document.getElementById('tooltip');
+    if (!_tooltipEl) return;
+    document.addEventListener('mouseover', _handleMouseOver);
+    document.addEventListener('mouseout', _handleMouseOut);
+    document.addEventListener('mousedown', _dismiss);
+}
+
+/**
+ * @param {MouseEvent} evt
+ * @returns {void}
+ */
+function _handleMouseOver(evt) {
+    const el = evt.target.closest('[data-tip]');
+    if (!el || el === _currentEl) return;
+    _currentEl = el;
+    clearTimeout(_showTimer);
+    if (_visible) {
+        _show(el); // adjacent-trigger swap: no re-delay, matches native tooltip feel
+    } else {
+        _showTimer = setTimeout(() => _show(el), SHOW_DELAY_MS);
+    }
+}
+
+/**
+ * mouseover/mouseout bubble, so hovering a child of the trigger fires
+ * mouseout(target=trigger, relatedTarget=child) then mouseover(target=child).
+ * Only react when the event concerns the element we're actually tracking, and
+ * only when relatedTarget has genuinely left it.
+ * @param {MouseEvent} evt
+ * @returns {void}
+ */
+function _handleMouseOut(evt) {
+    if (!_currentEl) return;
+    const el = evt.target.closest('[data-tip]');
+    if (el !== _currentEl) return;
+    if (evt.relatedTarget && _currentEl.contains(evt.relatedTarget)) return;
+    _dismiss();
+}
+
+/**
+ * @returns {void}
+ */
+function _dismiss() {
+    clearTimeout(_showTimer);
+    _hide();
+    _currentEl = null;
+}
+
+/**
+ * @param {HTMLElement} el
+ * @returns {void}
+ */
+function _show(el) {
+    if (_anchoredEl && _anchoredEl !== el) _anchoredEl.style.removeProperty('anchor-name');
+    el.style.setProperty('anchor-name', TOOLTIP_ANCHOR_NAME);
+    _anchoredEl = el;
+    _tooltipEl.textContent = el.dataset.tip;
+    _reparentToContext(el);
+    _tooltipEl.classList.add('visible');
+    _visible = true;
+}
+
+/**
+ * @returns {void}
+ */
+function _hide() {
+    _tooltipEl.classList.remove('visible');
+    if (_anchoredEl) _anchoredEl.style.removeProperty('anchor-name');
+    _anchoredEl = null;
+    _visible = false;
+}
+
+/**
+ * Moves the single tooltip element into the innermost open <dialog> ancestor
+ * of el, or back to <body> if el isn't inside a dialog. Dialogs shown via
+ * showModal() are promoted to the top layer, which paints above regular
+ * document content — a tooltip left in <body> would render invisibly behind
+ * an open dialog. Reparenting into the innermost open dialog also handles
+ * nested dialogs correctly, since that's the one painted last (highest).
+ * @param {HTMLElement} el
+ * @returns {void}
+ */
+function _reparentToContext(el) {
+    const targetParent = el.closest('dialog[open]') ?? document.body;
+    if (_tooltipEl.parentElement !== targetParent) targetParent.appendChild(_tooltipEl);
+}

--- a/public/js/ui/ui-functions-click/color-picker-expand.js
+++ b/public/js/ui/ui-functions-click/color-picker-expand.js
@@ -7,5 +7,5 @@ export function handleColorPickerExpand(_evt) {
     const btn = document.getElementById('color-picker-expand-btn');
     const expanded = dialog.classList.toggle('expanded');
     btn.setAttribute('aria-expanded', String(expanded));
-    btn.title = expanded ? 'Hide extra colours' : 'Show more colours';
+    btn.dataset.tip = expanded ? 'hide extra colours' : 'show more colours';
 }

--- a/public/js/ui/ui-functions-click/editor-color-pick.js
+++ b/public/js/ui/ui-functions-click/editor-color-pick.js
@@ -35,7 +35,7 @@ function makeCircleButton(name) {
     btn.className = 'color-circle';
     btn.dataset.action = 'color-circle-pick';
     btn.dataset.colorValue = name.startsWith('#') ? name.slice(1) : name;
-    btn.title = name;
+    btn.dataset.tip = name;
     if (name !== 'nocolor') btn.style.backgroundColor = name;
     return btn;
 }
@@ -48,7 +48,7 @@ function buildColorPickerContent() {
     dialog.classList.remove('expanded');
     const expandBtn = document.getElementById('color-picker-expand-btn');
     expandBtn.setAttribute('aria-expanded', 'false');
-    expandBtn.title = 'Show more colours';
+    expandBtn.dataset.tip = 'show more colours';
 
     // Row 1: nocolor first, then the curated COLOR_NAMES
     const row1 = document.createElement('div');

--- a/public/js/ui/ui-functions-render/a-render-filter.js
+++ b/public/js/ui/ui-functions-render/a-render-filter.js
@@ -15,7 +15,7 @@ function buildFilterHtml() {
             propertyLabel = filterObj.property;
             operator = filterObj.operator;
         }
-        html += `<button class="tag filter-pill" data-filterid="${filterId}" data-action="filter-togglestate" data-active="${isActive}" data-negate="${isNegate}">${propertyLabel}${operator}${filterObj.searchValue}(${filterObj.matchCount})<button class="btn-delete-filter" data-filterid="${filterId}" data-action="delete-filter">✕</button></button>`;
+        html += `<button class="tag filter-pill" data-filterid="${filterId}" data-action="filter-togglestate" data-active="${isActive}" data-negate="${isNegate}" data-tip="toggle filter">${propertyLabel}${operator}${filterObj.searchValue}(${filterObj.matchCount})<button class="btn-delete-filter" data-filterid="${filterId}" data-action="delete-filter" data-tip="remove filter">✕</button></button>`;
     }
     return html;
 }

--- a/public/js/ui/ui-functions-render/render-filename.js
+++ b/public/js/ui/ui-functions-render/render-filename.js
@@ -15,5 +15,5 @@ export function renderFilename(filename) {
  * @returns {string} The HTML string for the rendered filename and button.
  */
 export function renderFilenamePlusOpenBtn(filename, color, fileId) {
-    return `<span class="show-content-tag color-dynamic" data-color="${color}" data-file-id="${fileId}" data-action="open-file-content-modal">open</span><i>${filename}</i>`;
+    return `<span class="show-content-tag color-dynamic" data-color="${color}" data-file-id="${fileId}" data-action="open-file-content-modal" data-tip="open file">open</span><i>${filename}</i>`;
 }

--- a/public/js/ui/ui-functions-render/render-tags.js
+++ b/public/js/ui/ui-functions-render/render-tags.js
@@ -20,7 +20,7 @@ export function renderTags(tagname, tagcount = null, hash = "nohash", type = "ta
     const tag_type = type === "span" ? "" : "tag-pill"; // so we can style the tag differently according to where it is used (default is tag-pill style)
     const tagnamehash = (hash === "showhash") ? "#" + tagname : tagname; // for when we want to render tags inside the modal, need to show the # in front
     
-    const spanhtml = `<span class="tag ${tag_type}" data-tag="${tagname}" data-action="tag-filter" data-filterkey="tags-:-${tagname}" data-active="${active}">${tagnamehash}${tagcounter}</span>`
+    const spanhtml = `<span class="tag ${tag_type}" data-tag="${tagname}" data-action="tag-filter" data-filterkey="tags-:-${tagname}" data-active="${active}" data-tip="filter by #${tagname}">${tagnamehash}${tagcounter}</span>`
 
     return spanhtml;
 

--- a/public/js/ui/ui-functions-table/render-table-header.js
+++ b/public/js/ui/ui-functions-table/render-table-header.js
@@ -9,7 +9,7 @@ export function renderTableHeader(current_props) {
 
     // Generate the header cell HTML
     const headerCellsHtml = current_props
-        .map(prop => `<div class="note-table-cell-header flex-row">${prop.name}<span class="flexgrow"> </span><span data-property="${prop.name}" data-action="sort-object" class="sort-by-prop-trigger">˅</span></div>`)
+        .map(prop => `<div class="note-table-cell-header flex-row">${prop.name}<span class="flexgrow"> </span><span data-property="${prop.name}" data-action="sort-object" class="sort-by-prop-trigger" data-tip="sort by ${prop.name}">˅</span></div>`)
         .join('');
 
     // Generate the grid-template-columns value for the CSS

--- a/public/style.css
+++ b/public/style.css
@@ -40,6 +40,7 @@
 @import url("css/pagination.css");
 @import url("css/button-new-note.css");
 @import url("css/tag-autocomplete.css");
+@import url("css/tooltip.css");
 @import url("css/modal-color-picker.css");
 @import url("css/print.css");
 @import url("css/view-transitions-file-list.css");


### PR DESCRIPTION
Adds a single reused #tooltip element positioned via CSS anchor positioning (same technique as the tag-autocomplete popup), themed with the existing colour variables and reparented into the innermost open dialog so it paints above nested modals. Every clickable element now carries a data-tip attribute; existing title= tooltips are migrated to data-tip to avoid the native/custom tooltip clashing on hover.


Claude-Session: https://claude.ai/code/session_01V1LCzni27MpFceHxJn9Qbt