### PR TITLE
Fix tooltip flashing at wrong position during fade-out

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/public/js/ui/tooltip.js
+++ b/public/js/ui/tooltip.js
@@ -88,8 +88,6 @@ function _show(el) {
  */
 function _hide() {
     _tooltipEl.classList.remove('visible');
-    if (_anchoredEl) _anchoredEl.style.removeProperty('anchor-name');
-    _anchoredEl = null;
     _visible = false;
 }
 


### PR DESCRIPTION
_hide() cleared anchor-name from the hovered element in the same tick it started the CSS fade-out transition, so for the ~120ms the tooltip was still display:block, its anchor() references were unresolvable and it fell back to its static in-flow position. anchor-name now only changes in _show(), which already transfers it correctly between elements, so the fade-out plays out at the correct anchored position.


Claude-Session: https://claude.ai/code/session_01V1LCzni27MpFceHxJn9Qbt