### PR TITLE
Add welcome empty state, no-results message, and Alt+X shortcut listing

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,19 @@
 
     <div id="tag-taxonomy-container"></div>
 
-    <div id="output"></div>
+    <div id="output">
+      <div class="empty-state">
+        <h1>Gypsum</h1>
+        <p>A viewer for the text and markdown files on your computer.</p>
+        <p>Click <strong>folder</strong> (top left) to choose a folder of .txt / .md files.
+          Everything stays in your browser — nothing is uploaded.</p>
+        <p class="empty-state-shortcuts">
+          <span><kbd>/</kbd> search</span>
+          <span><kbd>#</kbd> tag search</span>
+          <span><kbd>?</kbd> settings</span>
+        </p>
+      </div>
+    </div>
   </main>
 
   <dialog id="modal-settings" closedby="any">
@@ -333,6 +345,7 @@
           <div><dt></dt><dd><kbd>Ctrl</kbd>+<kbd>→</kbd> etc</dd></div>
           <div><dt></dt><dd><kbd>PgUp</kbd> / <kbd>PgDn</kbd></dd></div>
           <div><dt>Open file</dt><dd><kbd>Enter</kbd> / <kbd>Space</kbd></dd></div>
+          <div><dt>Clear all filters</dt><dd><kbd>Alt</kbd>+<kbd>x</kbd></dd></div>
           <div><dt>Open settings</dt><dd><kbd>?</kbd></dd></div>
         </dl>
       </div>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/public/css/empty-state.css
+++ b/public/css/empty-state.css
@@ -1,0 +1,52 @@
+/* Welcome block shown in #output before a folder is loaded (static markup in
+   index.html) and the "no files match" message rendered by a-render-all-files.js. */
+
+.empty-state {
+    max-width: 480px;
+    margin: 10vh auto 0;
+    padding: 20px 28px;
+    text-align: center;
+    background-color: var(--colour-neutral-alt);
+    border: 2px solid transparent;
+    border-radius: 8px;
+    color: var(--colour-contr);
+}
+
+.empty-state h1 {
+    color: var(--colour-contr-emph);
+    margin: 0 0 12px;
+}
+
+.empty-state p {
+    margin: 0 0 12px;
+}
+
+.empty-state p:last-child {
+    margin-bottom: 0;
+}
+
+.empty-state-shortcuts {
+    display: flex;
+    justify-content: center;
+    column-gap: 18px;
+    flex-wrap: wrap;
+}
+
+.empty-state-shortcuts span {
+    white-space: nowrap;
+}
+
+.empty-state kbd {
+    --colour-soften-1: color-mix(in srgb, var(--colour-contr) 90%, transparent 10%);
+    --colour-soften-2: color-mix(in srgb, var(--colour-contr) 60%, transparent 40%);
+    --colour-soften-3: color-mix(in srgb, var(--colour-contr) 5%, transparent 95%);
+    padding: 1px 5px;
+    margin-inline: 2px;
+    color: var(--colour-soften-1);
+    border: 1px solid var(--colour-soften-2);
+    background-color: var(--colour-soften-3);
+    border-radius: 4px;
+    font-size: 0.89375em;
+    font-family: var(--fontfam-app-input);
+    line-height: 1.5;
+}

--- a/public/js/ui/ui-functions-render/a-render-all-files.js
+++ b/public/js/ui/ui-functions-render/a-render-all-files.js
@@ -57,6 +57,19 @@ export function renderFiles(fullRender = true, keepPage = false) {
         // Remove stale pagination nav (required for the table fullRender=false path)
         document.querySelector('.pagination')?.remove();
 
+        // Files are loaded but the active filters exclude all of them — show a
+        // message instead of a silently blank page. Safe to skip the view renderers:
+        // the table's fullRender=false path is only reachable from the header's own
+        // sort trigger, which is not in the DOM while this message is shown.
+        if (appState.myFiles.length > 0 && visibleFiles.length === 0) {
+            document.getElementById('output').innerHTML = `
+                <div class="empty-state">
+                    <p>No files match your filters.</p>
+                    <p>Press <kbd>Alt</kbd>+<kbd>x</kbd> or use the clear filters button to reset.</p>
+                </div>`;
+            return;
+        }
+
         switch(appState.viewState) {
             case VIEWS.CARDS.value:
                 renderFileList_grid(renderEverything);

--- a/public/style.css
+++ b/public/style.css
@@ -42,5 +42,6 @@
 @import url("css/tag-autocomplete.css");
 @import url("css/tooltip.css");
 @import url("css/modal-color-picker.css");
+@import url("css/empty-state.css");
 @import url("css/print.css");
 @import url("css/view-transitions-file-list.css");


### PR DESCRIPTION
- Show a "Gypsum" welcome block in #output before a folder is loaded, with a pointer to the folder button and key shortcuts
- Render a "no files match your filters" message when active filters exclude every file, instead of a silently blank page
- List the existing Alt+X clear-all-filters shortcut in the settings dialog's keyboard shortcuts reference
- Bump manifest version to 1.4.0


Claude-Session: https://claude.ai/code/session_01AKx5BL7fqAQ8gTyATB9JoC