### PR TITLE
Fix tooltip text wrapping and clarify shortcut tooltips with "press"

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <div id="modal-content" tabindex="0" class="color-dynamic-fade" data-color="">
         <div class="color-dynamic" id="file-content-header" data-color="">
 
-          <button id="save-btn" class="svg-wrapper-style" data-action="save-file-copy" data-tip="save file (Ctrl+S)">
+          <button id="save-btn" class="svg-wrapper-style" data-action="save-file-copy" data-tip="save file (press Ctrl+S)">
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 50 50" width="59.2" height="58"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><defs><path id="h7a2b" d="M0 0c-1.9-0.1-7.1-0.9-11.3-0.6-4.2 0.3-10.9 0.2-13.8 2.5-2.9 2.3-3.6 5.9-3.8 11.2-0.1 5.3-2.6 17.1 3.1 20.8 5.7 3.7 25.1 4.6 31 1.5 5.9-3.1 3.8-15.7 4.3-20.1 0.5-4.4 0.2-4-1.4-6.5-1.6-2.6-6.8-7.3-8.1-8.8z"/><path id="k9f4e" d="M0 0c-0.4 0.2-1.7 0.2-2.3 1-0.7 0.8-1.6 2.5-1.6 3.9 0 1.4 0.6 3.3 1.6 4.3 1 1 2.7 1.3 4.2 1.4 1.5 0.1 3.6-0.1 4.8-0.6 1.3-0.6 2.3-1.8 2.7-2.9 0.4-1.1 0.2-2.6-0.3-3.7-0.4-1.1-2-2.3-2.4-2.7"/><path id="m2d1c" d="M0 0c-0.3 0.8-1.4 3.9-1.7 4.7"/><path id="p5s8q" d="M0 0c0.9 0.2 4.4 0.8 5.3 0.9"/></defs><g transform="translate(39.5 10.7)"><use href="#h7a2b" fill="none"/></g><g transform="translate(19.1 18)"><path d="M1.2 0h14.2c0.8 0 1.2 0.4 1.2 1.2v2.5c0 0.8-0.4 1.2-1.2 1.2H1.2C0.4 4.9 0 4.5 0 3.7V1.2C0 0.4 0.4 0 1.2 0z" stroke="none"/><path d="M1.2 0h14.2M15.4 0c0.8 0 1.2 0.4 1.2 1.2v2.5c0 0.8-0.4 1.2-1.2 1.2H1.2C0.4 4.9 0 4.5 0 3.7V1.2C0 0.4 0.4 0 1.2 0" fill="none"/></g><g id="save-disk-arrow"><g transform="translate(25.1 29.9)"><use href="#k9f4e" fill="none"/></g><g transform="translate(31.1 29.7)"><use href="#m2d1c" fill="none"/></g><g transform="translate(31.4 29.8)"><use href="#p5s8q" fill="none"/></g></g></g></svg>
 
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 50 50" width="117.2" height="116.3"><g stroke="currentColor" fill="currentColor" stroke-width="4" stroke-linecap="round"><g transform="translate(21.1,34.1)"><path id="h1" d="M0 0C1.2.9,4 6.4,7 5.4C10 4.4,16.1-4.1,17.9-6" fill="none"/><use href="#h1"/></g><g transform="translate(38.9,10.7)"><path id="h2" d="M0 0C-1.9-.1,-7.1-.9,-11.3-.6C-15.5-.3,-22.2-.4,-25.1 1.9C-28 4.1,-28.7 7.7,-28.8 13.1C-29 18.4,-29 29.9,-25.8 33.9C-22.5 37.9,-14.8 37.2,-9.2 37.3C-3.7 37.4,4.5 38.2,7.6 34.6C10.7 30.9,9.5 19.6,9.6 15.3C9.7 11,9.7 11.4,8.1 8.8C6.5 6.3,1.4 1.5,0 0" fill="none"/><use href="#h2"/></g><g transform="translate(18.5,18)"><path d="M1.2 0C5 0,8.9 0,15.4 0C16.2 0,16.6.4,16.6 1.2C16.6 1.8,16.6 2.4,16.6 3.7C16.6 4.5,16.2 4.9,15.4 4.9C11.3 4.9,7.3 4.9,1.2 4.9C0.4 4.9,0 4.5,0 3.7C0 2.9,0 2,0 1.2C0 .4,.4 0,1.2 0" stroke="none"/><path d="M1.2 0C6.4 0,11.5 0,15.4 0M1.2 0C5.1 0,9 0,15.4 0M15.4 0C16.2 0,16.6.4,16.6 1.2M15.4 0C16.2 0,16.6.4,16.6 1.2M16.6 1.2C16.6 2.2,16.6 3.1,16.6 3.7M16.6 1.2C16.6 1.8,16.6 2.4,16.6 3.7M16.6 3.7C16.6 4.5,16.2 4.9,15.4 4.9M16.6 3.7C16.6 4.5,16.2 4.9,15.4 4.9M15.4 4.9C9.8 4.9,4.1 4.9,1.2 4.9M15.4 4.9C10.6 4.9,5.8 4.9,1.2 4.9M1.2 4.9C0.4 4.9,0 4.5,0 3.7M1.2 4.9C0.4 4.9,0 4.5,0 3.7M0 3.7C0 2.8,0 1.8,0 1.2M0 3.7C0 3.2,0 2.7,0 1.2M0 1.2C0 .4,.4 0,1.2 0M0 1.2C0 .4,.4 0,1.2 0" fill="none"/></g></g></svg>
@@ -32,7 +32,7 @@
 
           <select id="file-content-history-select" data-action="history-select-change" data-tip="file version history"></select>
 
-          <button data-action="file-options-open" class="svg-wrapper-style" id="file-options-btn" data-tip="file options (Ctrl+Shift+S)">
+          <button data-action="file-options-open" class="svg-wrapper-style" id="file-options-btn" data-tip="file options (press Ctrl+Shift+S)">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 82.2 79.5" width="82.2" height="79.5"><g stroke="currentColor" fill="currentColor" stroke-width="6" stroke-linecap="round"><defs><path id="h_x7a" d="M5.1 0h30.9m-30.9 0h30.9c3.4 0 5.1 1.7 5.1 5.1m-5.1-5.1c3.4 0 5.1 1.7 5.1 5.1m0 0c0 3.7 0 7.5 0 10.1m0-10.1c0 3.7 0 7.5 0 10.1m0 0c0 3.4-1.7 5.1-5.1 5.1m5.1-5.1c0 3.4-1.7 5.1-5.1 5.1m0 0H5.1m30.9 0H5.1c-3.4 0-5.1-1.7-5.1-5.1m5.1 5.1c-3.4 0-5.1-1.7-5.1-5.1m0 0V5.1m0 10.1V5.1C0 1.7 1.7 0 5.1 0m-5.1 5.1C0 1.7 1.7 0 5.1 0"/><path id="h_k9s" d="M0 0c-1 2.8-8.2 14.5-6.2 16.7 2 2.2 15.3-2.9 18.4-3.5"/><path id="h_m2v" d="M0 0C-4.2.8-21.1-3.3-25.4 4.9c-4.3 8.2-7.3 36.8-.2 44.4 7.2 7.6 35.3 4.3 43.2 1.2 7.9-3 3.5-16.2 4.2-19.5"/><path id="h_r4q" d="M0 0c.4.2 2.1.6 2.6 1.3.4.6.3 2.3.4 2.8"/></defs><use href="#h_x7a" transform="rotate(317.3 50.2 31.4) translate(29.6 21.2)" fill="none"/><use href="#h_k9s" transform="translate(28 39.5)" fill="none"/><use href="#h_m2v" transform="translate(39.8 15.5)" fill="none"/><use href="#h_r4q" transform="translate(22.1 52)"/></g></svg>
           </button>
 
@@ -54,7 +54,7 @@
 
         <div class="content-editable-controls">
           <div class="editor-btns">
-            <button data-action="editor-color-pick" class="svg-wrapper-style" data-tip="pick colour (Alt+C)">
+            <button data-action="editor-color-pick" class="svg-wrapper-style" data-tip="pick colour (press Alt+C)">
               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 7 48 40" width="56.8" height="54.4"><g stroke="currentColor" fill="none" stroke-width="4" stroke-linecap="round"><defs><circle id="c_7af8" cx="1.9" cy="1.9" r="1"/></defs><use href="#c_7af8" x="20.2" y="18.7"/><use href="#c_7af8" x="16.5" y="27"/><use href="#c_7af8" x="29.1" y="16.2"/><use href="#c_7af8" x="35.6" y="22.5"/><g transform="translate(28.3 10)"><path d="M0 0C1.1.1 4.5.1 6.5.8c2 .7 3.6 1.2 5.6 3.3 2 2.1 5.5 6 6.2 9.4.7 3.4-.4 8.7-1.9 10.8-1.5 2.1-5 1.8-7 1.8-2 0-3.3-1.5-4.8-1.8-1.5-.3-3.5-.5-4.4 0-.9.5-1.2 2-.7 3.1.5 1.1 3.3 2.3 3.9 3.4.6 1.1 1.6 3-.3 3.4-1.9.3-8.1 0-11.3-1.3-3.2-1.3-6.1-4-7.8-6.5-1.7-2.5-2.3-5.3-2.3-8.3 0-3 1.2-7 2.3-9.4 1.1-2.4 2.7-3.6 4.5-4.9 1.8-1.3 4.3-2.5 6.2-3.1 1.9-.7 4.4-.6 5.3-.6M0 0C1.1.1 4.5.1 6.5.8c2 .7 3.6 1.2 5.6 3.3 2 2.1 5.5 6 6.2 9.4.7 3.4-.4 8.7-1.9 10.8-1.5 2.1-5 1.8-7 1.8-2 0-3.3-1.5-4.8-1.8-1.5-.3-3.5-.5-4.4 0-.9.5-1.2 2-.7 3.1.5 1.1 3.3 2.3 3.9 3.4.6 1.1 1.6 3-.3 3.4-1.9.3-8.1 0-11.3-1.3-3.2-1.3-6.1-4-7.8-6.5-1.7-2.5-2.3-5.3-2.3-8.3 0-3 1.2-7 2.3-9.4 1.1-2.4 2.7-3.6 4.5-4.9 1.8-1.3 4.3-2.5 6.2-3.1 1.9-.7 4.4-.6 5.3-.6"/></g></g></svg>
             </button>
             <button data-action="editor-undo" class="svg-wrapper-style" data-tip="undo">
@@ -68,7 +68,7 @@
         
             <div class="flex-row label_group_text_toggle">
               <div>html</div>
-              <label for="render_toggle" class="switch" data-tip="switch between rendered and plain text (Alt+T)"><input type="checkbox" id="render_toggle" name="render_toggle"
+              <label for="render_toggle" class="switch" data-tip="switch between rendered and plain text (press Alt+T)"><input type="checkbox" id="render_toggle" name="render_toggle"
                   data-action="toggle-render-text"><span class="slider"></span></label>
               <div>txt</div>
             </div>
@@ -95,7 +95,7 @@
       <input type="checkbox" name="fullscreen" id="fullscreen" data-action="toggle-fullscreen">
     </label> -->
 
-    <button data-tip="open settings (?)" data-action="open-settings-modal" class="svg-wrapper-style">
+    <button data-tip="open settings (press ?)" data-action="open-settings-modal" class="svg-wrapper-style">
       <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="7 5 10 40" width="50" height="50"><g stroke="currentColor" fill="none" stroke-width="4" stroke-linecap="round"><defs><path id="k9x2p" d="M3.4 1.92 C3.4 2.04,3.4 2.15,3.38 2.26 C3.36 2.37,3.34 2.48,3.3 2.58 C3.27 2.69,3.23 2.79,3.18 2.89 C3.13 2.98,3.07 3.08,3.01 3.16 C2.94 3.25,2.87 3.33,2.8 3.4 C2.72 3.47,2.64 3.53,2.55 3.59 C2.47 3.65,2.38 3.69,2.28 3.73 C2.19 3.77,2.09 3.8,2 3.82 C1.9 3.84,1.8 3.85,1.7 3.85 C1.6 3.85,1.5 3.84,1.41 3.82 C1.31 3.8,1.21 3.77,1.12 3.73 C1.03 3.69,0.94 3.65,0.85 3.59 C0.77 3.53,0.68 3.47,0.61 3.4 C0.53 3.33,0.46 3.25,0.4 3.16 C0.33 3.08,0.28 2.98,0.23 2.89 C0.18 2.79,0.14 2.69,0.1 2.58 C0.07 2.48,0.04 2.37,0.03 2.26 C0.01 2.15,0 2.04,0 1.92 C0 1.81,0.01 1.7,0.03 1.59 C0.04 1.48,0.07 1.37,0.1 1.27 C0.14 1.16,0.18 1.06,0.23 0.96 C0.28 0.87,0.33 0.77,0.4 0.69 C0.46 0.6,0.53 0.52,0.61 0.45 C0.68 0.38,0.77 0.31,0.85 0.26 C0.94 0.2,1.03 0.15,1.12 0.12 C1.21 0.08,1.31 0.05,1.41 0.03 C1.5 0.01,1.6 0,1.7 0 C1.8 0,1.9 0.01,2 0.03 C2.09 0.05,2.19 0.08,2.28 0.12 C2.38 0.15,2.47 0.2,2.55 0.26 C2.64 0.31,2.72 0.38,2.8 0.45 C2.87 0.52,2.94 0.6,3.01 0.69 C3.07 0.77,3.13 0.87,3.18 0.96 C3.23 1.06,3.27 1.16,3.3 1.27 C3.34 1.37,3.36 1.48,3.38 1.59 C3.4 1.7,3.4 1.87,3.4 1.92 C3.41 1.98,3.41 1.87,3.4 1.92"/></defs><use href="#k9x2p" transform="translate(10.07 10)"/><use href="#k9x2p" transform="translate(10.32 22.28) rotate(51.8 1.7 1.92)"/><use href="#k9x2p" transform="translate(10.13 34.66) rotate(312.17 1.7 1.92)"/></g></svg>
     </button>
   </div>
@@ -115,9 +115,9 @@
 
           <div class="searchbox-container flexgrow">
             <input data-action="search-files" type="text" id="searchbox" name="searchbox" size="10"
-            minlength="3" maxlength="100" placeholder='' autocomplete="off" enterkeyhint="search" data-tip="search files (/)"/>
+            minlength="3" maxlength="100" placeholder='' autocomplete="off" enterkeyhint="search" data-tip="search files (press /)"/>
 
-            <button data-tip="search tags (#)" class="searchbox-tag-btn" data-action="start-tag-search">#</button>
+            <button data-tip="search tags (press #)" class="searchbox-tag-btn" data-action="start-tag-search">#</button>
           </div>
 
         </div>
@@ -137,7 +137,7 @@
           <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 45 40" width="54.3" height="51.6"><g stroke="#1e1e1e" fill="none" stroke-width="4" stroke-linecap="round"><g transform="translate(20.4,24.8)"><path d="M0 0C1.3-1.4 4.8-5.8 7.5-8.3C10.2-10.7 13.7-14.8 16.3-14.8C19-14.7 23.4-10.6 23.3-8.1C23.3-5.6 18.8-2.1 16.2.4C13.6 2.9 9.1 6 7.7 7.1"/></g><g transform="translate(21.9,25.2)"><path  id="highlight-nib" d="M0 0C-.6.8-3.9 3-3.8 4.6C-3.7 6.1-.9 9.1.6 9.3C2.1 9.5 5.3 7.3 5.2 5.8C5.1 4.2.9 1 0 0" fill="yellow" stroke="none"/><path d="M0 0C-.6.8-3.9 3-3.8 4.6C-3.7 6.1-.9 9.1.6 9.3C2.1 9.5 5.3 7.3 5.2 5.8C5.1 4.2.9 1 0 0"/></g><g transform="translate(10.8,37.3)"><path  id="highlight-line" d="M0 0C2.9.1 12.1.6 17.5.7C22.9.7 30 .4 32.5.3" stroke="yellow"/></g><g transform="translate(10,41.3)"><path d="M0 0C3 0 12.5.2 18.2.3C23.9.3 31.6.1 34.3.1"/></g></g></svg>
           <input type="checkbox" id="toggle-search-highlights" name="toggle-search-highlights" checked>
         </label>
-        <button id="clear-filters-btn" class="filter-options-position filters-options-style svg-wrapper-style" data-action="clear-all-filters" data-tip="clear all filters (Alt+X)">
+        <button id="clear-filters-btn" class="filter-options-position filters-options-style svg-wrapper-style" data-action="clear-all-filters" data-tip="clear all filters (press Alt+X)">
           <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="3 3 48 48" width="52.6" height="54.6"><g stroke="currentColor" fill="none" stroke-width="4" stroke-linecap="round"><g transform="translate(14.8 13.2)"><path d="M0 0C0 4.5-1.8 21.9 0 27.1C1.8 32.3 7.3 31.1 11 31.2C14.8 31.2 20.6 32.7 22.5 27.5C24.5 22.4 22.7 4.6 22.8 0M0 0C0 4.5-1.8 21.9 0 27.1C1.8 32.3 7.3 31.1 11 31.2C14.8 31.2 20.6 32.7 22.5 27.5C24.5 22.4 22.7 4.6 22.8 0"/></g><g transform="translate(42.6 13.3)"><path d="M0 0C-2.7-0.1-10.8-0.7-16.2-0.6C-21.7-0.6-29.9 0.2-32.7 0.4M0 0C-2.7-0.1-10.8-0.7-16.2-0.6C-21.7-0.6-29.9 0.2-32.7 0.4"/></g><g transform="translate(22.1 20.1)"><path d="M0 0C0 1-0 3.6 0 6.2C0 8.7 0.2 13.9 0.2 15.4M0 0C0 1-0 3.6 0 6.2C0 8.7 0.2 13.9 0.2 15.4"/></g><g transform="translate(30.1 20.5)"><path d="M0 0C0 1.3 0.2 5.1 0.2 7.6C0.2 10.1-0.1 13.6-0.2 14.8M0 0C0 1.3 0.2 5.1 0.2 7.6C0.2 10.1-0.1 13.6-0.2 14.8"/></g><g transform="translate(30.3 10)"><path d="M0 0C-1.5 0-7.5 0.2-9 0.2M0 0C-1.5 0-7.5 0.2-9 0.2"/></g></g></svg>
         </button>
 
@@ -406,7 +406,7 @@
     <div id="color-picker-content"></div>
   </dialog>
 
-  <button id="btn-new-note" data-action="create-new-note" disabled data-tip="new note (Alt+N)">+</button>
+  <button id="btn-new-note" data-action="create-new-note" disabled data-tip="new note (press Alt+N)">+</button>
 
   <div id="tooltip" aria-hidden="true"></div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/public/css/tooltip.css
+++ b/public/css/tooltip.css
@@ -15,7 +15,7 @@
     line-height: 1.2;
     padding: 4px 8px;
     border-radius: 4px;
-    white-space: nowrap;
+    white-space: normal;
     max-width: 240px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 

--- a/public/js/ui/render-file-list-grid.js
+++ b/public/js/ui/render-file-list-grid.js
@@ -36,7 +36,7 @@ export function renderFileList_grid(renderEverything) {
         // construct the html for the file as a whole, pulling in file content and tag pills from above.
   //      const tag_list = file.tags.join(" ");
         const filename_html = renderFilename(file.filepath);
-        const openFileTip = index <= 9 ? `open file (${index})` : 'open file';
+        const openFileTip = index <= 9 ? `open file (press ${index})` : 'open file';
         file_html += `
         <div class="note-grid keyboard-navigable color-dynamic" tabindex="0" data-index="${index}" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}" data-tip="${openFileTip}">
 

--- a/public/js/ui/render-file-list-peek.js
+++ b/public/js/ui/render-file-list-peek.js
@@ -30,7 +30,7 @@ export function renderFileList_peek(renderEverything) {
                 .replace(/>/g, '&gt;')
                 .replace(/\n/g, '<br>');
 
-            const openFileTip = index <= 9 ? `open file (${index})` : 'open file';
+            const openFileTip = index <= 9 ? `open file (press ${index})` : 'open file';
             file_html += `
         <div class="note-grid keyboard-navigable color-dynamic" tabindex="0" data-index="${index}" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}" data-tip="${openFileTip}">
 

--- a/public/js/ui/render-file-list-search.js
+++ b/public/js/ui/render-file-list-search.js
@@ -27,7 +27,7 @@ export function renderFileList_search(renderEverything) {
                 tag_pills_html += renderTags(tag);
             }
 
-            const openFileTip = index <= 9 ? `open file (${index})` : 'open file';
+            const openFileTip = index <= 9 ? `open file (press ${index})` : 'open file';
             file_html += `
                 <div class="search-view-item color-dynamic" data-color="${file.color}" data-file-id="${file.id}" data-action="open-file-content-modal" data-vt-id="${file.id}" data-tip="${openFileTip}">
 


### PR DESCRIPTION
Long tooltip text (e.g. the html/txt render toggle) was overflowing its box because #tooltip used white-space: nowrap; switching to normal lets it wrap within the existing max-width instead. Also prefixes each shortcut hint with "press" so it reads clearly as a keyboard shortcut rather than an ambiguous annotation.