### PR TITLE
Make array property pills in the Properties panel click-to-filter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gypsum",
   "short_name": "Gypsum",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#f1f1f1",

--- a/public/js/ui/event-listeners-add.js
+++ b/public/js/ui/event-listeners-add.js
@@ -4,6 +4,7 @@
  */
 
 import { handleTagClick } from './ui-functions-click/tag-filter-click.js';
+import { handlePropertyFilterClick } from './ui-functions-click/property-filter-click.js';
 import { handleFilterModeToggle } from './ui-functions-click/filter-mode-toggle.js';
 import { handleClearFilters } from './ui-functions-click/clear-filters.js';
 import { handleViewSelect } from './ui-functions-click/view-change.js';
@@ -73,6 +74,7 @@ export function addActionHandlers() {
 // Map 'data-action' names from html to their handler functions.
 const clickActionHandlers = {
     'tag-filter': handleTagClick,
+    'property-filter': handlePropertyFilterClick,
     'clear-all-filters': handleClearFilters,
     'open-file-content-modal': handleOpenFileContent,
     'close-file-content-modal': handleCloseModal,

--- a/public/js/ui/ui-functions-click/property-filter-click.js
+++ b/public/js/ui/ui-functions-click/property-filter-click.js
@@ -1,0 +1,23 @@
+import { addFilterThenFindMatches } from "../ui-functions-search/a-search-orchestrator.js";
+import { parseSearchString } from "../ui-functions-search/a-search-parse-string.js";
+
+/**
+ * Handles clicking an array value in the frontmatter Properties panel, triggering a search
+ * filter for that property:value pair — the same syntax and pathway the search box uses.
+ * Does not touch the open file-content modal; the file list re-renders underneath it.
+ * @param {Event} evt - The click event.
+ * @param {HTMLElement} target - The clicked element, carrying data-property and data-value.
+ * @returns {Promise<void>}
+ */
+export async function handlePropertyFilterClick(evt, target) {
+    const property = target.dataset.property;
+    const value = target.dataset.value;
+
+    if (!property || !value) {
+        console.error("Clicked element does not have data-property/data-value.");
+        return;
+    }
+
+    const searchObject = parseSearchString(value, property);
+    await addFilterThenFindMatches(searchObject);
+}

--- a/public/js/ui/ui-functions-render/render-frontmatter-properties.js
+++ b/public/js/ui/ui-functions-render/render-frontmatter-properties.js
@@ -1,7 +1,8 @@
 import { parseYaml } from '../../services/file-parsing/yaml-parse.js';
 
 /**
- * Escapes HTML-significant characters in a string so it can be safely injected into markup.
+ * Escapes HTML-significant characters in a string so it can be safely injected into markup,
+ * including as a quoted attribute value.
  * @param {string} value - The raw string to escape.
  * @returns {string} The escaped string.
  */
@@ -9,18 +10,26 @@ function escapeHtml(value) {
     return value
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 /**
  * Renders the HTML for a single property value, based on its type.
- * Arrays are rendered as tag-style pills; null is rendered as blank; everything else as text.
+ * Arrays are rendered as clickable, tag-style pills (each one triggers a search filter for
+ * `property:value`, the same syntax and pathway the search box uses); null is rendered as
+ * blank; everything else as text.
+ * @param {string} property - The property name the value belongs to.
  * @param {*} value - The property value, as produced by parseYaml.
  * @returns {string} The HTML string for the value cell.
  */
-function renderPropertyValue(value) {
+function renderPropertyValue(property, value) {
     if (Array.isArray(value)) {
-        return value.map(item => `<span class="tag tag-pill">${escapeHtml(String(item))}</span>`).join('');
+        return value.map(item => {
+            const itemText = escapeHtml(String(item));
+            return `<span class="tag tag-pill" data-action="property-filter" data-property="${escapeHtml(property)}" data-value="${itemText}" data-tip="search ${escapeHtml(property)}: ${itemText}">${itemText}</span>`;
+        }).join('');
     }
     if (value === null) {
         return '';
@@ -46,7 +55,7 @@ export function renderFrontmatterProperties(text) {
     }
 
     const rowsHtml = entries.map(([name, value]) =>
-        `<div class="frontmatter-prop-name">${escapeHtml(name)}</div><div class="frontmatter-prop-value">${renderPropertyValue(value)}</div>`
+        `<div class="frontmatter-prop-name">${escapeHtml(name)}</div><div class="frontmatter-prop-value">${renderPropertyValue(name, value)}</div>`
     ).join('');
 
     return `<div class="frontmatter-properties"><div class="frontmatter-properties-heading">Properties</div><div class="frontmatter-properties-grid">${rowsHtml}</div></div>`;


### PR DESCRIPTION
Each array value pill now carries data-action="property-filter" plus the property name and value. Clicking it builds a property:value search object and runs it through the same addFilterThenFindMatches pathway the search box uses, so it reuses existing filter dedup, case-insensitive property matching, and re-render logic. The uniqueId scheme (property-:-value) is identical to the one used elsewhere (e.g. tag pills), so clicking a "tags" value here shares filter state with the rest of the app. The open file-content modal is untouched — only the underlying file list re-renders.


Claude-Session: https://claude.ai/code/session_01KGNHR7PT1CWyzfjBbwM4nb